### PR TITLE
Add Gemfile, enable US Web Design Std integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,68 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    blankslate (2.1.2.4)
+    classifier-reborn (2.0.3)
+      fast-stemmer (~> 1.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.1.1)
+    colorator (0.1)
+    execjs (2.6.0)
+    fast-stemmer (1.0.2)
+    ffi (1.9.10)
+    jekyll (2.5.3)
+      classifier-reborn (~> 2.0)
+      colorator (~> 0.1)
+      jekyll-coffeescript (~> 1.0)
+      jekyll-gist (~> 1.0)
+      jekyll-paginate (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 2.6.1)
+      mercenary (~> 0.3.3)
+      pygments.rb (~> 0.6.0)
+      redcarpet (~> 3.1)
+      safe_yaml (~> 1.0)
+      toml (~> 0.1.0)
+    jekyll-coffeescript (1.0.1)
+      coffee-script (~> 2.2)
+    jekyll-gist (1.3.4)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    kramdown (1.9.0)
+    liquid (2.6.3)
+    listen (3.0.3)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
+    posix-spawn (0.3.11)
+    pygments.rb (0.6.3)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    rb-fsevent (0.9.6)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    redcarpet (3.3.3)
+    safe_yaml (1.0.4)
+    sass (3.4.19)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  redcarpet
+
+BUNDLED WITH
+   1.10.6

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,14 @@ name: 18F Brand
 exclude:
 - README.md
 - LICENSE
-- web-design-standards
+- web-design-standards/CONTRIBUTING.md
+- web-design-standards/Gemfile
+- web-design-standards/Gemfile.lock
+- web-design-standards/LICENSE.md
+- web-design-standards/README.md
+- web-design-standards/assets-styleguide
+- web-design-standards/go
+- web-design-standards/pages
 
 sass:
   style: compressed

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,2 +1,1 @@
   <script src="{{ site.baseurl }}/web-design-standards/assets/js/vendor/jquery-1.11.3.min.js"></script>
-  <script src="{{ site.baseurl }}/web-design-standards/assets-styleguide/js/styleguide.js"></script>

--- a/_plugins/uswds.rb
+++ b/_plugins/uswds.rb
@@ -1,0 +1,6 @@
+# Adds the US Web Design Standards to the Sass load path
+
+require 'sass'
+
+Sass.load_paths << File.join(File.dirname(File.dirname(__FILE__)),
+  'web-design-standards', 'assets', '_scss')

--- a/_sass/uswds
+++ b/_sass/uswds
@@ -1,1 +1,0 @@
-../web-design-standards/assets/_scss

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,32 +3,32 @@
 
 // Vendor -------------- //
 
-@import 'uswds/lib/bourbon/bourbon';
-@import 'uswds/lib/neat/neat';
-@import 'uswds/lib/normalize';
+@import 'lib/bourbon/bourbon';
+@import 'lib/neat/neat';
+@import 'lib/normalize';
 
 
 // Core -------------- //
 
-@import 'uswds/core/grid-settings';
-@import 'uswds/core/defaults';
-@import 'uswds/core/variables';
+@import 'core/grid-settings';
+@import 'core/defaults';
+@import 'core/variables';
 @import 'variables';
-@import 'uswds/core/base';
-@import 'uswds/core/grid';
-@import 'uswds/core/utilities';
+@import 'core/base';
+@import 'core/grid';
+@import 'core/utilities';
 
 
 // Elements -------------- //
 
-@import 'uswds/elements/typography';
-@import 'uswds/elements/list';
-@import 'uswds/elements/figure';
+@import 'elements/typography';
+@import 'elements/list';
+@import 'elements/figure';
 
 
 // Components -------------- //
 
-@import 'uswds/components/sidenav';
+@import 'components/sidenav';
 
 // Custom styles ---------- //
 


### PR DESCRIPTION
The symlink wasn't working due to the issues discussed in:
https://github.com/guard/listen/wiki/Duplicate-directory-errors

The solution was to write a very tiny plugin to add the web-design-standards
submodule to the Sass load paths, then explictly exclude all items from
web-design-standards that shouldn't appear in the output.

cc: @maya