### PR TITLE
Make footer sticky.

### DIFF
--- a/_sass/_styleguide.scss
+++ b/_sass/_styleguide.scss
@@ -129,11 +129,16 @@ $site-top:           98px;
 // Main Content --------- //
 
 .main-content {
+  display: flex;
+  flex-direction: column;
+
   @include media($medium-screen) {
     top: $site-top;
+    min-height: calc(100vh - #{$site-top});
   }
   position: absolute;
   top: 4rem;
+  min-height: calc(100vh - 4rem);
   bottom: 0;
   right: 0;
   width: 100%;
@@ -213,11 +218,8 @@ h2.styleguide-header {
 // Styleguide Content -------- //
 
 .styleguide-content {
+  flex: 1;
   margin-bottom: 5em;
-
-  /* This can artificially increase the height of the page, but it also
-   * guarantees that the footer always "sticks" to the bottom of it. */
-  min-height: 100vh;
 
   max-width: $site-max-width;
   padding: {
@@ -243,6 +245,10 @@ h2.styleguide-header {
 // Footer --------------- //
 
 .usa-styleguide-footer {
+// https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
+  flex-shrink: 0;
+  flex-basis: auto;
+
   background-color: $color-dark;;
   padding: {
     bottom: 3rem;

--- a/_sass/_styleguide.scss
+++ b/_sass/_styleguide.scss
@@ -214,6 +214,11 @@ h2.styleguide-header {
 
 .styleguide-content {
   margin-bottom: 5em;
+
+  /* This can artificially increase the height of the page, but it also
+   * guarantees that the footer always "sticks" to the bottom of it. */
+  min-height: 100vh;
+
   max-width: $site-max-width;
   padding: {
     left: 2em;

--- a/_sass/_styleguide.scss
+++ b/_sass/_styleguide.scss
@@ -133,8 +133,8 @@ $site-top:           98px;
   flex-direction: column;
 
   @include media($medium-screen) {
-    top: $site-top;
     min-height: calc(100vh - #{$site-top});
+    top: $site-top;
   }
   position: absolute;
   top: 4rem;
@@ -220,7 +220,6 @@ h2.styleguide-header {
 .styleguide-content {
   flex: 1;
   margin-bottom: 5em;
-
   max-width: $site-max-width;
   padding: {
     left: 2em;
@@ -245,11 +244,12 @@ h2.styleguide-header {
 // Footer --------------- //
 
 .usa-styleguide-footer {
-// https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
+  background-color: $color-dark;;
+
+  // https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
   flex-shrink: 0;
   flex-basis: auto;
 
-  background-color: $color-dark;;
   padding: {
     bottom: 3rem;
     top: 3rem;


### PR DESCRIPTION
When the page content isn't enough to fill the whole viewport, the footer isn't actually at the bottom of the page:

![footer](https://cloud.githubusercontent.com/assets/124687/15588117/6a385854-235a-11e6-9f04-3a6f01444349.png)

~~This PR isn't an ideal fix, but it basically ensures that the content element is at least the full height of the viewport, so that the footer is always at the very bottom of the page. However, the downside of this fix is that in such cases, the footer actually needs to be scrolled-down to. So it's OK if you end up rejecting this PR. (The traditional sticky footer fix requires a fixed-height footer, which I don't like, and the [flexbox version](https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/) was exhibiting some weird graphical anomalies. So that's why I didn't go either of those routes.)~~

This PR uses a [flexbox-based sticky footer](https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/) to always force the footer to the bottom of the page like so:

![sticky-footer](https://cloud.githubusercontent.com/assets/124687/15606608/3bb3baec-23db-11e6-95be-ea601ca573ae.png)

Browsers that don't support flexbox, like IE9, will revert to the old behavior, which is still perfectly legible.
