### PR TITLE
Upgrade to Jekyll 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 .sass-cache/
+.jekyll-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
-gem 'redcarpet'
+gem 'jekyll', '3.1.6'
+gem 'redcarpet', '3.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,68 +1,41 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
-    classifier-reborn (2.0.3)
-      fast-stemmer (~> 1.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.9.1.1)
     colorator (0.1)
-    execjs (2.6.0)
-    fast-stemmer (1.0.2)
     ffi (1.9.10)
-    jekyll (2.5.3)
-      classifier-reborn (~> 2.0)
+    jekyll (3.1.6)
       colorator (~> 0.1)
-      jekyll-coffeescript (~> 1.0)
-      jekyll-gist (~> 1.0)
-      jekyll-paginate (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 2.6.1)
+      liquid (~> 3.0)
       mercenary (~> 0.3.3)
-      pygments.rb (~> 0.6.0)
-      redcarpet (~> 3.1)
+      rouge (~> 1.7)
       safe_yaml (~> 1.0)
-      toml (~> 0.1.0)
-    jekyll-coffeescript (1.0.1)
-      coffee-script (~> 2.2)
-    jekyll-gist (1.3.4)
-    jekyll-paginate (1.1.0)
-    jekyll-sass-converter (1.3.0)
-      sass (~> 3.2)
-    jekyll-watch (1.3.0)
-      listen (~> 3.0)
-    kramdown (1.9.0)
-    liquid (2.6.3)
-    listen (3.0.3)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    mercenary (0.3.5)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
-    posix-spawn (0.3.11)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
-    rb-fsevent (0.9.6)
-    rb-inotify (0.9.5)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.4.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.11.1)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.3.3)
+    rouge (1.10.1)
     safe_yaml (1.0.4)
-    sass (3.4.19)
-    toml (0.1.2)
-      parslet (~> 1.5.0)
-    yajl-ruby (1.2.1)
+    sass (3.4.22)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll
-  redcarpet
+  jekyll (= 3.1.6)
+  redcarpet (= 3.3.3)
 
 BUNDLED WITH
-   1.10.6
+   1.12.4


### PR DESCRIPTION
This upgrades the project from Jekyll 2.5.3 to 3.1.6.

The main benefit I was hoping to take advantage of was Jekyll 3's [incremental regeneration](http://idratherbewriting.com/2015/11/04/jekyll-30-released-incremental-regeneration-rocks/). Currently making a simple change to the site's SASS takes a couple seconds on my machine, which makes rapidly tinkering with styling a bit more cumbersome, and I was hoping that running jekyll with `--incremental` would speed it up, but it doesn't. :disappointed: 

In any case, though, there are probably other benefits to using Jekyll 3 that I don't know about, and it's probably a good idea to upgrade sooner anyways since support for 2.x will be dropped at some point. I browsed the built website with this new version and there don't seem to be any regressions, so it looks like a safe upgrade to me...

Note that in order to take advantage of this update you'll need to re-run `bundle install`.