### PR TITLE
Make color matrix accessible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll', '3.1.6'
 gem 'redcarpet', '3.3.3'
+gem 'wcag_color_contrast', '0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
+    wcag_color_contrast (0.0.1)
 
 PLATFORMS
   ruby
@@ -36,6 +37,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (= 3.1.6)
   redcarpet (= 3.3.3)
+  wcag_color_contrast (= 0.0.1)
 
 BUNDLED WITH
    1.12.4

--- a/_data/palette.yml
+++ b/_data/palette.yml
@@ -1,17 +1,17 @@
 - name: white
-  hex: '#FFFFFF'
+  hex: 'FFFFFF'
 
 - name: light
-  hex: '#B3EFFF'
+  hex: 'B3EFFF'
 
 - name: bright
-  hex: '#00CFFF'
+  hex: '00CFFF'
 
 - name: medium
-  hex: '#046B99'
+  hex: '046B99'
 
 - name: dark
-  hex: '#1C304A'
+  hex: '1C304A'
 
 - name: black
-  hex: '#000000'
+  hex: '000000'

--- a/_data/palette.yml
+++ b/_data/palette.yml
@@ -1,0 +1,17 @@
+- name: white
+  hex: '#FFFFFF'
+
+- name: light
+  hex: '#B3EFFF'
+
+- name: bright
+  hex: '#00CFFF'
+
+- name: medium
+  hex: '#046B99'
+
+- name: dark
+  hex: '#1C304A'
+
+- name: black
+  hex: '#000000'

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -8,7 +8,7 @@
 <div class="usa-matrix-legend">
   <svg><use xlink:href="#usa-matrix-bad-contrast-ratio"/></svg>
 
-  <p>
+  <p class="usa-sr-invisible" aria-hidden="true">
     Please don't use these color combinations; they do not meet a color
     contrast ratio of 4.5:1, so they do not conform with the standards of
     Section 508 for body text. This means that some people would have
@@ -27,7 +27,7 @@
             {{ foreground.name | capitalize }} text<br>
             <small>#{{ foreground.hex }}</small><br>
           </div>
-          <strong class="usa-matrix-foreground-{{ foreground.name }}">
+          <strong class="usa-matrix-foreground-{{ foreground.name }} usa-sr-invisible" aria-hidden="true">
             Aa
           </strong>
         </td>
@@ -53,22 +53,27 @@
       {% if ratio >= 4.5 %}
       <td class="usa-matrix-valid-color-combo">
         <div class="usa-matrix-square usa-color-{{ background.name }}"
-             title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}.">
-          <strong class="usa-matrix-foreground-{{ foreground.name }}">
+             title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}."
+             role="presentation">
+          <strong class="usa-matrix-foreground-{{ foreground.name }} usa-sr-invisible" aria-hidden="true">
             Aa
           </strong>
         </div>
-        <aside>
+        <div class="usa-matrix-color-combo-description">
           <strong>{{ foreground.name | capitalize }}</strong> text on
           <strong>{{ background.name }}</strong> background
-        </aside>
+          <span class="usa-sr-only">is 508-compliant, with a contrast ratio of {{ ratio | human_readable_contrast_ratio }}.</span>
+        </div>
       </td>
       {% else %}
       <td class="usa-matrix-invalid-color-combo">
-        <div title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text.">
+        <div title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text." role="presentation">
           <svg class="usa-matrix-square">
             <use xlink:href="#usa-matrix-bad-contrast-ratio"/>
           </svg>
+        </div>
+        <div class="usa-sr-only">
+          Do not use {{ foreground.name }} text on {{ background.name }} background; it is not 508-compliant, with a contrast ratio of {{ ratio | human_readable_contrast_ratio }}.
         </div>
       </td>
       {% endif %}

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -5,7 +5,7 @@
       {% for foreground in site.data.palette %}
         <td scope="col">
           {{ foreground.name | capitalize }} text<br>
-          <small>{{ foreground.hex }}</small><br>
+          <small>#{{ foreground.hex }}</small><br>
           <strong class="usa-matrix-foreground-{{ foreground.name }}">
             Aa
           </strong>
@@ -21,7 +21,7 @@
       <td scope="row">
         <div class="usa-matrix-square usa-color-{{ background.name }}"></div>
         {{ background.name | capitalize }} background<br>
-        <small>{{ background.hex }}</small>
+        <small>#{{ background.hex }}</small>
       </td>
       {% for foreground in site.data.palette %}
       <td>

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -53,7 +53,7 @@
       {% if ratio >= 4.5 %}
       <td class="usa-matrix-valid-color-combo">
         <div class="usa-matrix-square usa-color-{{ background.name }}"
-             title="The color ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}.">
+             title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}.">
           <strong class="usa-matrix-foreground-{{ foreground.name }}">
             Aa
           </strong>
@@ -65,7 +65,7 @@
       </td>
       {% else %}
       <td class="usa-matrix-invalid-color-combo">
-        <div title="The color ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text.">
+        <div title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text.">
           <svg class="usa-matrix-square">
             <use xlink:href="#usa-matrix-bad-contrast-ratio"/>
           </svg>

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -1,0 +1,52 @@
+<table class="usa-table-borderless usa-matrix">
+  <thead>
+    <tr>
+      <td scope="col"></td>
+      {% for foreground in site.data.palette %}
+        <td scope="col">
+          {{ foreground.name | capitalize }} text<br>
+          <small>{{ foreground.hex }}</small><br>
+          <strong class="usa-matrix-foreground-{{ foreground.name }}">
+            Aa
+          </strong>
+        </td>
+      {% endfor %}
+    </tr>
+  </thead>
+
+  <tbody>
+  {% assign reversed_palette = site.data.palette | reverse %}
+  {% for background in reversed_palette %}
+    <tr>
+      <td scope="row">
+        <div class="usa-matrix-square usa-color-{{ background.name }}"></div>
+        {{ background.name | capitalize }} background<br>
+        <small>{{ background.hex }}</small>
+      </td>
+      {% for foreground in site.data.palette %}
+      <td>
+        <div class="usa-matrix-square usa-color-{{ background.name }}">
+          <strong class="usa-matrix-foreground-{{ foreground.name }}">
+            Aa
+          </strong>
+        </div>
+      </td>
+      {% endfor %}
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+<!--
+TODO: Hide bad color combinations and show the legend below.
+
+<p>
+  <small>
+  Please don't use these color combinations; they do not meet a color
+  contrast ratio of 4.5:1, so they do not conform with the standards of
+  Section 508 for body text. This means that some people would have
+  difficulty reading the text. Employing accessibility best practices
+  improves the user experience for all users.
+  </small>
+</p>
+-->

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -47,13 +47,13 @@
         {% assign ratio = foreground.hex | contrast_ratio with: background.hex %}
         {% if ratio >= 4.5 %}
         <div class="usa-matrix-square usa-color-{{ background.name }}"
-             title="The color ratio of {{ foreground.name }} on {{ background.name }} is about {{ ratio | floor }}:1.">
+             title="The color ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}.">
           <strong class="usa-matrix-foreground-{{ foreground.name }}">
             Aa
           </strong>
         </div>
         {% else %}
-        <div title="The color ratio of {{ foreground.name }} on {{ background.name }} is about {{ ratio | floor }}:1, which does not conform with the standards of Section 508 for body text.">
+        <div title="The color ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text.">
           <svg class="usa-matrix-square">
             <use xlink:href="#usa-matrix-bad-contrast-ratio"/>
           </svg>

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -40,10 +40,12 @@
   {% for background in reversed_palette %}
     <tr>
       <td scope="row">
-        <div class="usa-matrix-square usa-color-{{ background.name }}"></div>
-        <div class="usa-matrix-desc">
-          {{ background.name | capitalize }} background<br>
-          <small>#{{ background.hex }}</small>
+        <div>
+          <div class="usa-matrix-square usa-color-{{ background.name }}"></div>
+          <div class="usa-matrix-desc">
+            {{ background.name | capitalize }} background<br>
+            <small>#{{ background.hex }}</small>
+          </div>
         </div>
       </td>
       {% for foreground in site.data.palette %}

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -25,11 +25,17 @@
       </td>
       {% for foreground in site.data.palette %}
       <td>
-        <div class="usa-matrix-square usa-color-{{ background.name }}">
+        {% assign ratio = foreground.hex | contrast_ratio with: background.hex %}
+        {% if ratio >= 4.5 %}
+        <div class="usa-matrix-square usa-color-{{ background.name }}"
+             title="The color ratio of {{ foreground.name }} on {{ background.name }} is about {{ ratio | floor }}:1.">
           <strong class="usa-matrix-foreground-{{ foreground.name }}">
             Aa
           </strong>
         </div>
+        {% else %}
+          NOPE
+        {% endif %}
       </td>
       {% endfor %}
     </tr>

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -1,3 +1,22 @@
+<svg class="usa-matrix-symbol-definitions">
+  <symbol id="usa-matrix-bad-contrast-ratio" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="#f0f0f0"/>
+    <line x1="0" y1="100" x2="100" y2="0" stroke="white" stroke-width="4"/>
+  </symbol>
+</svg>
+
+<div class="usa-matrix-legend">
+  <svg><use xlink:href="#usa-matrix-bad-contrast-ratio"/></svg>
+
+  <p>
+    Please don't use these color combinations; they do not meet a color
+    contrast ratio of 4.5:1, so they do not conform with the standards of
+    Section 508 for body text. This means that some people would have
+    difficulty reading the text. Employing accessibility best practices
+    improves the user experience for all users.
+  </p>
+</div>
+
 <table class="usa-table-borderless usa-matrix">
   <thead>
     <tr>
@@ -34,7 +53,11 @@
           </strong>
         </div>
         {% else %}
-          NOPE
+        <div title="The color ratio of {{ foreground.name }} on {{ background.name }} is about {{ ratio | floor }}:1, which does not conform with the standards of Section 508 for body text.">
+          <svg class="usa-matrix-square">
+            <use xlink:href="#usa-matrix-bad-contrast-ratio"/>
+          </svg>
+        </div>
         {% endif %}
       </td>
       {% endfor %}
@@ -42,17 +65,3 @@
   {% endfor %}
   </tbody>
 </table>
-
-<!--
-TODO: Hide bad color combinations and show the legend below.
-
-<p>
-  <small>
-  Please don't use these color combinations; they do not meet a color
-  contrast ratio of 4.5:1, so they do not conform with the standards of
-  Section 508 for body text. This means that some people would have
-  difficulty reading the text. Employing accessibility best practices
-  improves the user experience for all users.
-  </small>
-</p>
--->

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -23,8 +23,10 @@
       <td scope="col"></td>
       {% for foreground in site.data.palette %}
         <td scope="col">
-          {{ foreground.name | capitalize }} text<br>
-          <small>#{{ foreground.hex }}</small><br>
+          <div class="usa-matrix-desc">
+            {{ foreground.name | capitalize }} text<br>
+            <small>#{{ foreground.hex }}</small><br>
+          </div>
           <strong class="usa-matrix-foreground-{{ foreground.name }}">
             Aa
           </strong>
@@ -39,26 +41,35 @@
     <tr>
       <td scope="row">
         <div class="usa-matrix-square usa-color-{{ background.name }}"></div>
-        {{ background.name | capitalize }} background<br>
-        <small>#{{ background.hex }}</small>
+        <div class="usa-matrix-desc">
+          {{ background.name | capitalize }} background<br>
+          <small>#{{ background.hex }}</small>
+        </div>
       </td>
       {% for foreground in site.data.palette %}
-      <td>
-        {% assign ratio = foreground.hex | contrast_ratio with: background.hex %}
-        {% if ratio >= 4.5 %}
+      {% assign ratio = foreground.hex | contrast_ratio with: background.hex %}
+      {% if ratio >= 4.5 %}
+      <td class="usa-matrix-valid-color-combo">
         <div class="usa-matrix-square usa-color-{{ background.name }}"
              title="The color ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}.">
           <strong class="usa-matrix-foreground-{{ foreground.name }}">
             Aa
           </strong>
         </div>
-        {% else %}
+        <aside>
+          <strong>{{ foreground.name | capitalize }}</strong> text on
+          <strong>{{ background.name }}</strong> background
+        </aside>
+      </td>
+      {% else %}
+      <td class="usa-matrix-invalid-color-combo">
         <div title="The color ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text.">
           <svg class="usa-matrix-square">
             <use xlink:href="#usa-matrix-bad-contrast-ratio"/>
           </svg>
         </div>
-        {% endif %}
+      </td>
+      {% endif %}
       </td>
       {% endfor %}
     </tr>

--- a/_plugins/contrast_ratio.rb
+++ b/_plugins/contrast_ratio.rb
@@ -1,0 +1,10 @@
+require 'liquid'
+require 'wcag_color_contrast'
+
+module ContrastRatio
+  def contrast_ratio(color1, color2)
+    WCAGColorContrast.ratio(color1, color2)
+  end
+end
+
+Liquid::Template.register_filter(ContrastRatio)

--- a/_plugins/contrast_ratio.rb
+++ b/_plugins/contrast_ratio.rb
@@ -5,6 +5,18 @@ module ContrastRatio
   def contrast_ratio(color1, color2)
     WCAGColorContrast.ratio(color1, color2)
   end
+
+  def human_readable_contrast_ratio(ratio)
+    if ratio < 4
+      ndigits = 1
+    elsif ratio < 5
+      ndigits = 2
+    else
+      ndigits = 0
+    end
+
+    "#{ratio.round(ndigits)}:1"
+  end
 end
 
 Liquid::Template.register_filter(ContrastRatio)

--- a/_sass/_color-matrix.scss
+++ b/_sass/_color-matrix.scss
@@ -1,3 +1,5 @@
+$marge-screen: 992px;
+
 .usa-matrix-foreground-white {
   color: $color-white;
 
@@ -27,11 +29,6 @@
 
 .usa-matrix-foreground-black {
   color: $color-black;
-}
-
-td[scope="row"] .usa-matrix-square {
-  float: left;
-  margin-right: 8px;
 }
 
 .usa-matrix td {
@@ -68,5 +65,61 @@ td[scope="row"] .usa-matrix-square {
   p {
     margin-left: 45px;
     font-size: 0.75em;
+  }
+}
+
+@media (min-width: $marge-screen) and (max-width: $large-screen) {
+  table th, table td {
+    padding: 0.5em;
+  }
+
+  .usa-matrix-desc {
+    font-size: 0.75em;
+  }
+}
+
+@media (min-width: $marge-screen) {
+  td.usa-matrix-valid-color-combo aside {
+    display: none;
+  }
+}
+
+@media (max-width: "#{$marge-screen - 1}") {
+  .usa-matrix-legend {
+    display: none;
+  }
+
+  table.usa-matrix {
+    display: block;
+
+    thead {
+      display: none;
+    }
+
+    tbody {
+      display: block;
+
+      tr {
+        display: block;
+
+        td.usa-matrix-valid-color-combo {
+          display: flex;
+          align-items: center;
+
+          aside {
+            flex: 1;
+            padding-left: 1em;
+          }
+        }
+
+        td.usa-matrix-invalid-color-combo {
+          display: none;
+        }
+
+        td[scope="row"] {
+          display: none;
+        }
+      }
+    }
   }
 }

--- a/_sass/_color-matrix.scss
+++ b/_sass/_color-matrix.scss
@@ -1,3 +1,5 @@
+// "Marge" is a cross between USWDS's "Medium" and "Large" breakpoints.
+// It's the equivalent of Bootstrap's "Medium" size.
 $marge-screen: 992px;
 
 .usa-matrix-foreground-white {

--- a/_sass/_color-matrix.scss
+++ b/_sass/_color-matrix.scss
@@ -2,6 +2,25 @@
 // It's the equivalent of Bootstrap's "Medium" size.
 $marge-screen: 992px;
 
+// The WAI-ARIA specification states the following about aria-hidden:
+//
+//   Authors MAY, with caution, use aria-hidden to hide visibly rendered
+//   content from assistive technologies only if the act of hiding this
+//   content is intended to improve the experience for users of assistive
+//   technologies by removing redundant or extraneous content. Authors
+//   using aria-hidden to hide visible content from screen readers MUST
+//   ensure that identical or equivalent meaning and functionality is
+//   exposed to assistive technologies.
+//
+// Unfortunately, however, the U.S. Web Design Standards forcibly set
+// anything with aria-hidden to display: none, making it difficult to
+// address the above use case. The following rule allows us to override
+// this default and create content that is visible to sighted users but
+// irrelevant to non-sighted users.
+.usa-sr-invisible[aria-hidden="true"] {
+  display: block !important;
+}
+
 .usa-matrix-foreground-white {
   color: $color-white;
 
@@ -105,8 +124,8 @@ td[scope="row"] > div {
 }
 
 @media (min-width: $marge-screen) {
-  td.usa-matrix-valid-color-combo aside {
-    display: none;
+  .usa-matrix-color-combo-description {
+    @include sr-only();
   }
 }
 
@@ -132,7 +151,7 @@ td[scope="row"] > div {
           display: flex;
           align-items: center;
 
-          aside {
+          .usa-matrix-color-combo-description {
             flex: 1;
             padding-left: 1em;
           }

--- a/_sass/_color-matrix.scss
+++ b/_sass/_color-matrix.scss
@@ -70,13 +70,37 @@ $marge-screen: 992px;
   }
 }
 
-@media (min-width: $marge-screen) and (max-width: $large-screen) {
+td[scope="row"] > div {
+  display: flex;
+
+  .usa-matrix-desc {
+    flex: 1;
+  }
+}
+
+@media (min-width: $marge-screen) and (max-width: "#{$large-screen - 1}") {
   table th, table td {
     padding: 0.5em;
   }
 
   .usa-matrix-desc {
     font-size: 0.75em;
+  }
+
+  td[scope="row"] > div {
+    flex-direction: column;
+
+    .usa-matrix-desc {
+      padding-top: 0.5em;
+    }
+  }
+}
+
+@media (min-width: $large-screen) {
+  td[scope="row"] > div {
+    .usa-matrix-desc {
+      padding-left: 0.5em;
+    }
   }
 }
 

--- a/_sass/_color-matrix.scss
+++ b/_sass/_color-matrix.scss
@@ -1,0 +1,51 @@
+.usa-matrix-foreground-white {
+  color: $color-white;
+
+  // https://css-tricks.com/adding-stroke-to-web-text/
+  text-shadow:
+   -1px -1px 0 #000,
+    1px -1px 0 #000,
+    -1px 1px 0 #000,
+     1px 1px 0 #000;
+}
+
+.usa-matrix-foreground-light {
+  color: $color-light;
+}
+
+.usa-matrix-foreground-bright {
+  color: $color-bright;
+}
+
+.usa-matrix-foreground-medium {
+  color: $color-medium;
+}
+
+.usa-matrix-foreground-dark {
+  color: $color-dark;
+}
+
+.usa-matrix-foreground-black {
+  color: $color-black;
+}
+
+td[scope="row"] .usa-matrix-square {
+  float: left;
+  margin-right: 8px;
+}
+
+.usa-matrix td {
+  vertical-align: top;
+}
+
+.usa-matrix-square {
+  width: 4em;
+  height: 4em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  strong {
+    text-shadow: none;
+  }
+}

--- a/_sass/_color-matrix.scss
+++ b/_sass/_color-matrix.scss
@@ -49,3 +49,24 @@ td[scope="row"] .usa-matrix-square {
     text-shadow: none;
   }
 }
+
+.usa-matrix-symbol-definitions {
+  display: none;
+}
+
+.usa-matrix-legend {
+  position: relative;
+
+  svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 35px;
+    height: 35px;
+  }
+
+  p {
+    margin-left: 45px;
+    font-size: 0.75em;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -38,3 +38,4 @@
 // Custom styles ---------- //
 
 @import 'styleguide';
+@import 'color-matrix';

--- a/visual-style.html
+++ b/visual-style.html
@@ -20,7 +20,7 @@ title: Visual style
   <div class="usa-color-square usa-color-{{ color.name }} {% cycle '', 'usa-mobile-end-row' %}">
     <div class="usa-color-inner-content">
       <p class="usa-color-name">{{ color.name }}</p>
-      <p class="usa-color-hex">{{ color.hex }}</p>
+      <p class="usa-color-hex">#{{ color.hex }}</p>
     </div>
   </div>
   {% endfor %}

--- a/visual-style.html
+++ b/visual-style.html
@@ -16,42 +16,14 @@ title: Visual style
 <p>Color palettes to use with Illustrator, Sketch, and Keynote</p>
 
 <div class="usa-grid-full usa-color-row usa-primary-color-section">
-  <div class="usa-color-square usa-color-white">
+  {% for color in site.data.palette %}
+  <div class="usa-color-square usa-color-{{ color.name }} {% cycle '', 'usa-mobile-end-row' %}">
     <div class="usa-color-inner-content">
-      <p class="usa-color-name">white</p>
-      <p class="usa-color-hex">#FFFFFF</p>
+      <p class="usa-color-name">{{ color.name }}</p>
+      <p class="usa-color-hex">{{ color.hex }}</p>
     </div>
   </div>
-  <div class="usa-color-square usa-color-light usa-mobile-end-row">
-    <div class="usa-color-inner-content">
-      <p class="usa-color-name">light</p>
-      <p class="usa-color-hex">#B3EFFF</p>
-    </div>
-  </div>
-  <div class="usa-color-square usa-color-bright">
-    <div class="usa-color-inner-content">
-      <p class="usa-color-name">bright</p>
-      <p class="usa-color-hex">#00CFFF</p>
-    </div>
-  </div>
-  <div class="usa-color-square usa-color-medium usa-mobile-end-row">
-    <div class="usa-color-inner-content">
-      <p class="usa-color-name">medium</p>
-      <p class="usa-color-hex">#046B99</p>
-    </div>
-  </div>
-  <div class="usa-color-square usa-color-dark">
-    <div class="usa-color-inner-content">
-      <p class="usa-color-name">dark</p>
-      <p class="usa-color-hex">#1C304A</p>
-    </div>
-  </div>
-  <div class="usa-color-square usa-color-black usa-mobile-end-row">
-    <div class="usa-color-inner-content">
-      <p class="usa-color-name">black</p>
-      <p class="usa-color-hex">#000000</p>
-    </div>
-  </div>
+  {% endfor %}
 </div>
 
 <br>

--- a/visual-style.html
+++ b/visual-style.html
@@ -30,6 +30,8 @@ title: Visual style
 <h3>Color combinations for text and backgrounds</h3>
 <p>This matrix shows how to use the 18F brand colors for text and backgrounds in combinations that conform with the standards of Section 508 of the Rehabilitation Act. For more on color contrast, read <a href="https://pages.18f.gov/accessibility/color/" target='_blank' title='Opens in new window'>18F's Accessibility Guide</a>. Each of the combinations shown below meets or exceeds a contrast ratio of 4.5:1, and is approved for body text and headline text.</p>
 
+{% include color-matrix.html %}
+
 <br>
 <img src="{{ site.baseurl }}/assets/img/18F-color-palette.png" alt="18F color palette">
 <br>

--- a/visual-style.html
+++ b/visual-style.html
@@ -32,10 +32,6 @@ title: Visual style
 
 {% include color-matrix.html %}
 
-<br>
-<img src="{{ site.baseurl }}/assets/img/18F-color-palette.png" alt="18F color palette">
-<br>
-
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Color_Palette.zip">Download color palettes</a>
 
 <h2 class="styleguide-header" id="typography">Typography</h2>


### PR DESCRIPTION
This is an attempt to make the color matrix accessible, and also generally easier to modify if needed, by converting it to HTML. It fixes #51.

For the duration of this PR, you can view the proposed changes live at https://brand-html-color-matrix.apps.cloud.gov/visual-style/#colors.

Here's a screenshot of the HTML color matrix on **Large** screens (≥1201px, as defined by USWDS):

![color-matrix](https://cloud.githubusercontent.com/assets/124687/15707652/e6ecca76-27c7-11e6-8373-e1231b81f1ba.png)

I also defined a new breakpoint called **Marge** (≥992px), which is like a cross between USWDS's Medium (≥600px) and Large. It's based off Bootstrap's "Medium" size.

On Marge screens, the table cell padding is condensed, the fonts are a bit smaller, and the first column is laid out vertically:

![marge](https://cloud.githubusercontent.com/assets/124687/15749324/f1f313ba-28af-11e6-8f83-7f14eff3bb83.png)

Finally, anything smaller than Marge gets the mobile treatment, which is a compromise between @rtwell's awesome mockups in https://github.com/18F/brand/issues/51#issuecomment-223129613, the existing markup, and time constraints. It looks more like a list than a table, and non-508-compliant color combinations are simply hidden from view:

![small](https://cloud.githubusercontent.com/assets/124687/15749378/2ada24ac-28b0-11e6-9232-1c5877d43c6f.png)

I think that @rtwell's original mockups are still a good ideal to strive for; perhaps we should keep an issue around to eventually "upgrade" the mobile version to be closer to those?

## Notes

* On desktop, hovering over the color squares (including the 508-non-compliant ones) shows a tooltip indicating the color contrast ratio. For instance, hovering over the top-left square has a tooltip that says "The color ratio of white on black is 21:1".

* The HTML markup for the palette and color matrix entries are generated dynamically. The palette is now stored in `_data/palette.yml`.

* The contrast ratio of the color matrix entries is dynamically generated via the [`wcag_color_contrast` gem](https://github.com/mkdynamic/wcag_color_contrast). Curiously, it claims that the color contrast of **medium on light** is 4.68:1, which is greater than the WCAG minimum ratio of 4.5:1, so that combination is present on this new matrix, but it is *not* present on the old one. Any ideas on this @jenniferthibault @rtwell ?

* Hopefully this code can be reused in any other projects we do that involve style guides and color palettes, such as perhaps the cloud.gov style guide.

* I've tested the matrix out on the latest versions of Edge, Firefox, Chrome, and Safari. It looks fine on all of them.

* I've also tested out the color matrix in NVDA and VoiceOver and it sounds decent in both.

## To Do

- [x] Blank-out 508-unfriendly color combinations.
- [x] Change the blanked-out 508-unfriendly entries to look more like they do in the original image.
- [x] Actually make sure the table reads well on screen readers.
- [x] Figure out what to do on mobile devices.