### PR TITLE
Preparing the site for public viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,7 @@
 # 18F Brand
-This is the home of 18F's evolving brand assets and style guide. It's a work in progress, and we are releasing new assets incrementally. For now, it's an internal tool only, which is why it's hosted on staging and you can’t get to the site without authenticating. 
+This is the home of 18F's evolving brand assets and style guide. It's a work in progress, and we are releasing new assets as we are able.
 
-Come visit us in #18f-branding on slack for help with implementing these assets, questions, or to philosophize on the meaning of type.
-
-## Assets available now:
-- Logo files
-- Favicon files
-- Color palette and preliminary text/background color guidance to conform with 508 standards.
-- 18F Nimbus font files
-- Keynote template and example presentation
- - Including a compatible version for Keynote 6.5, for users with OS X Yosemite,  and  version for Keynote 6.6, for users with El Capitan
-- Google Slides template and instructions on how to install the custom theme
-- Desktop art
-
-## Coming soon:
-- More templates (Google slides, Good docs, & many more)
-- Better guidance on how to use colors, fonts, logos, and other design assets
-- and more! We're adapting to our team's needs as we go, so if there's something you'd like to see us build or offer guidance on, file an issue in this repository.
+Come visit us in [#18f-branding](https://18f.slack.com/archives/18f-branding) on slack for help with implementing these assets, questions, or to philosophize on the meaning of type.
 
 ## Contributing
 

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -9,11 +9,7 @@
   <svg><use xlink:href="#usa-matrix-bad-contrast-ratio"/></svg>
 
   <p class="usa-sr-invisible" aria-hidden="true">
-    Please don't use these color combinations; they do not meet a color
-    contrast ratio of 4.5:1, so they do not conform with the standards of
-    Section 508 for body text. This means that some people would have
-    difficulty reading the text. Employing accessibility best practices
-    improves the user experience for all users.
+    <strong>Don't</strong> use these color combinations. They don’t have enough contrast to meet accessibility standards, and some people will have difficulty reading the text.
   </p>
 </div>
 

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -9,7 +9,7 @@
   <svg><use xlink:href="#usa-matrix-bad-contrast-ratio"/></svg>
 
   <p class="usa-sr-invisible" aria-hidden="true">
-    <strong>Don't</strong> use these color combinations. They don’t have enough contrast to meet accessibility standards, and some people will have difficulty reading the text.
+    <strong>Don’t</strong> use these color combinations. They don’t have enough contrast to meet accessibility standards, and some people will have difficulty reading the text.
   </p>
 </div>
 

--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -9,7 +9,7 @@
   <svg><use xlink:href="#usa-matrix-bad-contrast-ratio"/></svg>
 
   <p class="usa-sr-invisible" aria-hidden="true">
-    <strong>Don’t</strong> use these color combinations. They don’t have enough contrast to meet accessibility standards, and some people will have difficulty reading the text.
+    <strong>Don&rsquo;t</strong> use these color combinations. They don&rsquo;t have enough contrast to meet accessibility standards, and some people will have difficulty reading the text.
   </p>
 </div>
 

--- a/_sass/_styleguide.scss
+++ b/_sass/_styleguide.scss
@@ -200,6 +200,7 @@ h2.styleguide-header {
 
   a {
     color: $color-medium;
+    text-decoration: none;
 
     &:hover {
       color: $color-medium;
@@ -443,6 +444,11 @@ h1, h2, h3, h4, h5, h6 {
 
 a {
   color: $color-medium;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 .usa-sidenav-list {

--- a/_sass/_styleguide.scss
+++ b/_sass/_styleguide.scss
@@ -41,11 +41,15 @@ $site-top:           98px;
       width: 70%;
 
       a {
-        color: $color-dark;;
+        color: $color-dark;
 
         &:hover {
           color: $color-gray-dark;
           text-decoration: none;
+        }
+
+        &:visited {
+          color: $color-dark;
         }
       }
 
@@ -448,6 +452,10 @@ a {
 
   &:hover {
     text-decoration: none;
+  }
+
+  &:visited {
+    color: $color-medium;
   }
 }
 

--- a/pages/color-palette.html
+++ b/pages/color-palette.html
@@ -4,7 +4,7 @@ layout: default
 title: Color palette
 ---
 
-<p>Color palettes for Adobe, Sketch, and Mac applications</p>
+<p>For Adobe, Sketch, and Mac applications</p>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Color_Palette.zip">Download color palettes</a>
 
 <div class="usa-grid-full usa-color-row usa-primary-color-section">
@@ -21,7 +21,7 @@ title: Color palette
 <br>
 
 <h2>Instructions for Keynote</h2>
-<p>Install the color palette in Keynote to use it in any iWork application:</p>
+<p>Install the color palette to use it in any iWork application:</p>
 	<ol>
 		<li>
 			Open the <strong>18F_Color_Palette.zip</strong> file to unzip it.
@@ -36,7 +36,7 @@ title: Color palette
 			Click the <strong>gear icon > Open…</strong>
 		</li>
 		<li>
-			In the <strong>18F_Color_Palette</strong> folder, select <strong>18F_brand_colors.clr</strong> and click Open.
+			In the <strong>18F_Color_Palette</strong> folder, select <strong>18F_brand_colors.clr</strong> and click <strong>Open</strong>.
 		</li>
 	</ol>
 
@@ -45,5 +45,3 @@ title: Color palette
 
 
 {% include color-matrix.html %}
-
-

--- a/pages/color-palette.html
+++ b/pages/color-palette.html
@@ -4,7 +4,8 @@ layout: default
 title: Color palette
 ---
 
-<p>Color palettes to use with Illustrator, Sketch, and Keynote</p>
+<p>Color palettes for Adobe, Sketch, and Mac applications</p>
+<a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Color_Palette.zip">Download color palettes</a>
 
 <div class="usa-grid-full usa-color-row usa-primary-color-section">
   {% for color in site.data.palette %}
@@ -18,9 +19,31 @@ title: Color palette
 </div>
 
 <br>
-<h3>Color combinations for text and backgrounds</h3>
-<p>This matrix shows how to use the 18F brand colors for text and backgrounds in combinations that conform with the standards of Section 508 of the Rehabilitation Act. For more on color contrast, read <a href="https://pages.18f.gov/accessibility/color/" target='_blank' title='Opens in new window'>18F's Accessibility Guide</a>. Each of the combinations shown below meets or exceeds a contrast ratio of 4.5:1, and is approved for body text and headline text.</p>
+
+<h2>Instructions for Keynote</h2>
+<p>Install the color palette in Keynote to use it in any iWork application:</p>
+	<ol>
+		<li>
+			Open the <strong>18F_Color_Palette.zip</strong> file to unzip it.
+		</li>
+		<li>
+			In Keynote, press the <strong>Shift + Command + C</strong> keys to open the Colors menu.
+		</li>
+		<li>
+			Click the <strong>Color Palettes</strong> tab.
+		</li>
+		<li>
+			Click the <strong>gear icon > Open…</strong>
+		</li>
+		<li>
+			In the <strong>18F_Color_Palette</strong> folder, select <strong>18F_brand_colors.clr</strong> and click Open.
+		</li>
+	</ol>
+
+<h2>Guidelines</h2>
+<p><strong>Do</strong> use the 18F brand colors in combinations that conform with accessibility standards. Each of these combinations meets or exceeds a contrast ratio of 4.5:1, and is approved for body and headline text. For more details on color contrast, read the <a href="https://pages.18f.gov/accessibility/">18F Accessibility Guide</a>.</p>
+
 
 {% include color-matrix.html %}
 
-<a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Color_Palette.zip">Download color palettes</a>
+

--- a/pages/desktop-art.html
+++ b/pages/desktop-art.html
@@ -4,7 +4,23 @@ layout: default
 title: Desktop art
 ---
 
-<p>Desktop art for Thunderbolt monitors and powerbooks</p>
+<p>A variety of wallpaper images for MacBooks and Apple Displays.</p>
 <img src="{{ site.baseurl }}/assets/img/18FDesktop-Preview.png">
 <br><br>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Desktop_Art.zip">Download desktop art</a>
+
+<h2>Instructions</h2>
+<ol>
+	<li>In <strong>System Preferences</strong>, open <strong>Desktop &amp; Screensaver</strong>.</li>
+	<li>On the <strong>Desktop</strong> tab, click the + button.</li>
+	<li>Find the <strong>18F_Desktop_Art</strong> folder and click <strong>Choose</strong>.</li>
+	<li>Choose your desktop wallpaper on the right.</li>
+</ol>
+
+<h3>Image credits</h3>
+<ul>
+	<li>Flag, <a href="https://unsplash.com/photos/xn4Lc-87_fM">Eric Duvauchelle</a></li>
+	<li>Sky, <a href="http://tumblr.unsplash.com/post/54230079634/download-tumprins">Tumprins</a></li>
+	<li>Statue of Liberty, <a href="https://unsplash.com/photos/ciJJ57qsQLs">Anthony Delanoix</a></li>
+	<li>Highway, <a href="https://unsplash.com/photos/BYu8ITUWMfc/">Israel Sundseth</a></li>
+</ul>

--- a/pages/desktop-art.html
+++ b/pages/desktop-art.html
@@ -12,7 +12,7 @@ title: Desktop art
 <h2>Instructions</h2>
 <ol>
 	<li>In <strong>System Preferences</strong>, open <strong>Desktop &amp; Screensaver</strong>.</li>
-	<li>On the <strong>Desktop</strong> tab, click the + button.</li>
+	<li>On the <strong>Desktop</strong> tab, click the <strong>+</strong> button.</li>
 	<li>Find the <strong>18F_Desktop_Art</strong> folder and click <strong>Choose</strong>.</li>
 	<li>Choose your desktop wallpaper on the right.</li>
 </ol>

--- a/pages/introduction.html
+++ b/pages/introduction.html
@@ -6,19 +6,19 @@ title: Introduction
 
 <p>This toolkit was developed for 18F employees, but we hope it’s a useful reference for anyone, whether you’re on another design team or a member of the press.</p>
 
-<h3>If you work at 18F</h3>
+<h2>If you work at 18F</h2>
 <p>Our visual identity is a flexible system that helps you communicate clearly while building visual consistency across our work. It features a growing set of templates and guides you can use to meet common design needs — and save time in the process.</p>
 
 <p>This identity is integral to our ability to communicate our goals and deliver high-quality products. We recognize that having a strong brand is as important for government agencies as it is for private companies, and our users expect nothing less.</p>
 
 <p>Because a brand communicates <a href="https://pages.18f.gov/core-values/">our core values</a>, it helps us build trust with our partners, increase engagement, foster input and open-source contributions, and improve the public’s perception of government, all of which are central to <a href="https://github.com/18F/core-values/blob/18f-pages/pages/vision-mission.md">our mission</a>.</p>
 
-<h3>If you work at another organization</h3>
+<h2>If you work at another organization</h2>
 <p>As a work of the federal government, this project is in the public domain within the United States. Additionally, we waive copyright and related rights in the work worldwide through the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal public domain dedication</a>.</p>
 
 <p>Feel free to use the format of this guide with your own branding and identity. Please don’t use our visual styles as your own, though. These templates, color palettes, and styles are reflective of our core values, and won’t necessarily translate well for your organization and your communication goals.</p>
 
-<h3>Feedback or questions</h3>
+<h2>Feedback or questions</h2>
 <p>This is not a complete brand style guide, and it’s still an early draft. We’ll continue adding to this as we can, but there is no dedicated team at the moment.</p> 
 
 <p>We welcome your feedback and contributions so that we can continue to chip away at the highest priority needs for the 18F team. If you have any suggestions or are interested in getting involved, please chat us in <a href="https://18f.slack.com/archives/18f-branding">#18f-branding</a> or <a href="https://github.com/18F/brand/issues/new">create an issue in GitHub</a>.</p>

--- a/pages/introduction.html
+++ b/pages/introduction.html
@@ -4,22 +4,22 @@ layout: default
 title: Introduction
 ---
 
-<p>This toolkit was developed for 18F employees, but we hope it’s a useful reference for anyone, whether you’re on another design team or a member of the press.</p>
+<p>This toolkit was developed for 18F employees, but we hope it&rsquo;s a useful reference for anyone, whether you&rsquo;re on another design team or a member of the press.</p>
 
 <h2>If you work at 18F</h2>
 <p>Our visual identity is a flexible system that helps you communicate clearly while building visual consistency across our work. It features a growing set of templates and guides you can use to meet common design needs — and save time in the process.</p>
 
 <p>This identity is integral to our ability to communicate our goals and deliver high-quality products. We recognize that having a strong brand is as important for government agencies as it is for private companies, and our users expect nothing less.</p>
 
-<p>Because a brand communicates <a href="https://pages.18f.gov/core-values/">our core values</a>, it helps us build trust with our partners, increase engagement, foster input and open-source contributions, and improve the public’s perception of government, all of which are central to <a href="https://github.com/18F/core-values/blob/18f-pages/pages/vision-mission.md">our mission</a>.</p>
+<p>Because a brand communicates <a href="https://pages.18f.gov/core-values/">our core values</a>, it helps us build trust with our partners, increase engagement, foster input and open-source contributions, and improve the public&rsquo;s perception of government, all of which are central to <a href="https://github.com/18F/core-values/blob/18f-pages/pages/vision-mission.md">our mission</a>.</p>
 
 <h2>If you work at another organization</h2>
 <p>As a work of the federal government, this project is in the public domain within the United States. Additionally, we waive copyright and related rights in the work worldwide through the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal public domain dedication</a>.</p>
 
-<p>Feel free to use the format of this guide with your own branding and identity. Please don’t use our visual styles as your own, though. These templates, color palettes, and styles are reflective of our core values, and won’t necessarily translate well for your organization and your communication goals.</p>
+<p>Feel free to use the format of this guide with your own branding and identity. Please don&rsquo;t use our visual styles as your own, though. These templates, color palettes, and styles are reflective of our core values, and won&rsquo;t necessarily translate well for your organization and your communication goals.</p>
 
 <h2>Feedback or questions</h2>
-<p>This is not a complete brand style guide, and it’s still an early draft. We’ll continue adding to this as we can, but there is no dedicated team at the moment.</p> 
+<p>This is not a complete brand style guide, and it&rsquo;s still an early draft. We&rsquo;ll continue adding to this as we can, but there is no dedicated team at the moment.</p>
 
 <p>We welcome your feedback and contributions so that we can continue to chip away at the highest priority needs for the 18F team. If you have any suggestions or are interested in getting involved, please chat us in <a href="https://18f.slack.com/archives/18f-branding">#18f-branding</a> or <a href="https://github.com/18F/brand/issues/new">create an issue in GitHub</a>.</p>
 
@@ -38,4 +38,3 @@ title: Introduction
 		<a href="https://www.apple.com/support/mac-apps/keynote/">Apple Keynote Support</a>
 	</li>
 </ul>
-

--- a/pages/introduction.html
+++ b/pages/introduction.html
@@ -4,8 +4,30 @@ layout: default
 title: Introduction
 ---
 
-<p>18F’s brand toolkit is a flexible, easy-to-use system that helps you communicate clearly while building visual consistency across our team’s work. It features a growing set of templates and guides you can use to meet common design needs — and save time!</p>
+<p>This toolkit was developed for 18F employees, but we hope it’s a useful reference for anyone, whether you’re on another design team or a member of the press.</p>
 
-<p>Our ability to communicate our goals and deliver high-quality products and services is inseparable from our visual identity. We recognize that having a strong brand is just as important for government agencies as it is for private companies — our users expect nothing less.</p>
+<h3>If you work at 18F</h3>
+<p>Our visual identity is a flexible system that helps you communicate clearly while building visual consistency across our work. It features a growing set of templates and guides you can use to meet common design needs — and save time in the process.</p>
 
-<p>Because a brand communicates our core values, it helps us build trust with our users, increase engagement, foster public input and open-source contributions, and improve the public’s perception of government, all of which are central to our mission.</p>
+<p>This identity is integral to our ability to communicate our goals and deliver high-quality products. We recognize that having a strong brand is as important for government agencies as it is for private companies, and our users expect nothing less.</p>
+
+<p>Because a brand communicates <a href="https://pages.18f.gov/core-values/">our core values</a>, it helps us build trust with our partners, increase engagement, foster input and open-source contributions, and improve the public’s perception of government, all of which are central to <a href="https://github.com/18F/core-values/blob/18f-pages/pages/vision-mission.md">our mission</a>.</p>
+
+<h3>If you work at another organization</h3>
+<p>As a work of the federal government, this project is in the public domain within the United States. Additionally, we waive copyright and related rights in the work worldwide through the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal public domain dedication</a>.</p>
+
+<p>Feel free to use the format of this guide with your own branding and identity. Please don’t use our visual styles as your own, though. These templates, color palettes, and styles are reflective of our core values, and won’t necessarily translate well for your organization and your communication goals.</p>
+
+<h3>Feedback or questions</h3>
+<p>This is not a complete brand style guide, and it’s still an early draft. We’ll continue adding to this as we can, but there is no dedicated team at the moment.</p> 
+
+<p>We welcome your feedback and contributions so that we can continue to chip away at the highest priority needs for the 18F team. If you have any suggestions or are interested in getting involved, please chat us in <a href="https://18f.slack.com/archives/18f-branding">#18f-branding</a> or <a href="https://github.com/18F/brand/issues/new">create an issue in GitHub</a>.</p>
+
+<h3>Related links</h3>
+<ul>
+	<li><a href="https://pages.18f.gov/content-guide/">18F Content Guide</a></li>
+	<li><a href="https://standards.usa.gov/">Draft U.S. Web Design Standards</a></li>
+	<li><a href="https://support.google.com/docs/topic/19431">Getting Started with Google Slides</a></li>
+	<li><a href="https://www.apple.com/support/mac-apps/keynote/">Apple Keynote Support</a></li>
+</ul>
+

--- a/pages/introduction.html
+++ b/pages/introduction.html
@@ -25,9 +25,17 @@ title: Introduction
 
 <h3>Related links</h3>
 <ul>
-	<li><a href="https://pages.18f.gov/content-guide/">18F Content Guide</a></li>
-	<li><a href="https://standards.usa.gov/">Draft U.S. Web Design Standards</a></li>
-	<li><a href="https://support.google.com/docs/topic/19431">Getting Started with Google Slides</a></li>
-	<li><a href="https://www.apple.com/support/mac-apps/keynote/">Apple Keynote Support</a></li>
+	<li>
+		<a href="https://pages.18f.gov/content-guide/">18F Content Guide</a>
+	</li>
+	<li>
+		<a href="https://standards.usa.gov/">Draft U.S. Web Design Standards</a>
+	</li>
+	<li>
+		<a href="https://support.google.com/docs/topic/19431">Getting Started with Google Slides</a>
+	</li>
+	<li>
+		<a href="https://www.apple.com/support/mac-apps/keynote/">Apple Keynote Support</a>
+	</li>
 </ul>
 

--- a/pages/logo.html
+++ b/pages/logo.html
@@ -24,12 +24,12 @@ title: Logo
 		<strong>Do</strong> ask in <a href="https://18f.slack.com/archives/18f-branding">#18f-branding</a> when you have questions.
 	</li>
 	<li>
-		<strong>Don't</strong> change the color of the logo.
+		<strong>Don’t</strong> change the color of the logo.
 	</li>
 	<li>
-		<strong>Don't</strong> place the logo over images.
+		<strong>Don’t</strong> place the logo over images.
 	</li>
 	<li>
-		<strong>Don't</strong> stretch or skew the logo.
+		<strong>Don’t</strong> stretch or skew the logo.
 	</li>
 </ul>

--- a/pages/logo.html
+++ b/pages/logo.html
@@ -8,3 +8,28 @@ title: Logo
 <img class="display-logo" src="{{ site.baseurl }}/assets/img/18F-Logo-M.png" alt="18F logo">
 <br><br>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Logo.zip">Download logo</a>
+
+<h3>Guidelines</h3>
+<ul>
+	<li>
+		<strong>Do</strong> use the black version of the logo over a white background as your default. Bright blue (#00cfff) and white do not have enough contrast to meet accessibility requirements for low-vision users. Even though logos can be an exception to this rule, we prefer to follow best practices, and use black as our primary logo color. The bright blue version of the logo should only be used if you are using a dark page background. You can see an example of this in our presentation themes.
+	</li>
+	<li>
+		<strong>Do</strong> keep adequate white space around the logo. At any size, there should be half a logo’s-width of white space between the logo and any other object or border.
+	</li>
+	<li>
+		<strong>Do</strong> use the SVG logo whenever possible. It has a small file size and renders well at any scale. PNG is an acceptable fallback if the format of your document doesn’t support SVG.
+	</li>
+	<li>
+		<strong>Do</strong> ask in <a href="https://18f.slack.com/archives/18f-branding">#18f-branding</a> when you have questions.
+	</li>
+	<li>
+		<strong>Don't</strong> change the color of the logo.
+	</li>
+	<li>
+		<strong>Don't</strong> place the logo over images.
+	</li>
+	<li>
+		<strong>Don't</strong> stretch or skew the logo.
+	</li>
+</ul>

--- a/pages/logo.html
+++ b/pages/logo.html
@@ -15,21 +15,21 @@ title: Logo
 		<strong>Do</strong> use the black version of the logo over a white background as your default. Bright blue (#00cfff) and white do not have enough contrast to meet accessibility requirements for low-vision users. Even though logos can be an exception to this rule, we prefer to follow best practices, and use black as our primary logo color. The bright blue version of the logo should only be used if you are using a dark page background. You can see an example of this in our <a href="{{ site.baseurl }}/presentation-themes/">presentation themes</a>.
 	</li>
 	<li>
-		<strong>Do</strong> keep adequate white space around the logo. At any size, there should be half a logo’s-width of white space between the logo and any other object or border.
+		<strong>Do</strong> keep adequate white space around the logo. At any size, there should be half a logo&rsquo;s-width of white space between the logo and any other object or border.
 	</li>
 	<li>
-		<strong>Do</strong> use the SVG logo whenever possible. It has a small file size and renders well at any scale. PNG is an acceptable fallback if the format of your document doesn’t support SVG.
+		<strong>Do</strong> use the SVG logo whenever possible. It has a small file size and renders well at any scale. PNG is an acceptable fallback if the format of your document doesn&rsquo;t support SVG.
 	</li>
 	<li>
 		<strong>Do</strong> ask in <a href="https://18f.slack.com/archives/18f-branding">#18f-branding</a> when you have questions.
 	</li>
 	<li>
-		<strong>Don’t</strong> change the color of the logo.
+		<strong>Don&rsquo;t</strong> change the color of the logo.
 	</li>
 	<li>
-		<strong>Don’t</strong> place the logo over images.
+		<strong>Don&rsquo;t</strong> place the logo over images.
 	</li>
 	<li>
-		<strong>Don’t</strong> stretch or skew the logo.
+		<strong>Don&rsquo;t</strong> stretch or skew the logo.
 	</li>
 </ul>

--- a/pages/logo.html
+++ b/pages/logo.html
@@ -9,7 +9,7 @@ title: Logo
 <br><br>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Logo.zip">Download logo</a>
 
-<h3>Guidelines</h3>
+<h2>Guidelines</h2>
 <ul>
 	<li>
 		<strong>Do</strong> use the black version of the logo over a white background as your default. Bright blue (#00cfff) and white do not have enough contrast to meet accessibility requirements for low-vision users. Even though logos can be an exception to this rule, we prefer to follow best practices, and use black as our primary logo color. The bright blue version of the logo should only be used if you are using a dark page background. You can see an example of this in our presentation themes.

--- a/pages/logo.html
+++ b/pages/logo.html
@@ -12,7 +12,7 @@ title: Logo
 <h2>Guidelines</h2>
 <ul>
 	<li>
-		<strong>Do</strong> use the black version of the logo over a white background as your default. Bright blue (#00cfff) and white do not have enough contrast to meet accessibility requirements for low-vision users. Even though logos can be an exception to this rule, we prefer to follow best practices, and use black as our primary logo color. The bright blue version of the logo should only be used if you are using a dark page background. You can see an example of this in our presentation themes.
+		<strong>Do</strong> use the black version of the logo over a white background as your default. Bright blue (#00cfff) and white do not have enough contrast to meet accessibility requirements for low-vision users. Even though logos can be an exception to this rule, we prefer to follow best practices, and use black as our primary logo color. The bright blue version of the logo should only be used if you are using a dark page background. You can see an example of this in our <a href="{{ site.baseurl }}/presentation-themes/">presentation themes</a>.
 	</li>
 	<li>
 		<strong>Do</strong> keep adequate white space around the logo. At any size, there should be half a logo’s-width of white space between the logo and any other object or border.

--- a/pages/presentation-themes.html
+++ b/pages/presentation-themes.html
@@ -4,7 +4,7 @@ layout: default
 title: Presentation themes
 ---
 
-<p>Templates for Google Slides and Keynote</p>
+<p>For Google Slides and Keynote</p>
 
 <img src="{{ site.baseurl }}/assets/img/Template_Preview.png">
 <br><br>
@@ -20,7 +20,7 @@ title: Presentation themes
 	<li>Search for <strong>18F_Theme_GoogleSlides</strong>.</li>
 	<li>Select and import the theme.</li>
 </ol>
-<p>When using the 18F template, you can choose different layouts by selecting and inserting master pages. For more details, learn about <a href="https://support.google.com/docs/answer/1694986?hl=en">custom layouts and themes</a>.</p>
+<p>You can choose different layouts by selecting and inserting master pages from the template. For more details, learn about <a href="https://support.google.com/docs/answer/1694986?hl=en">custom layouts and themes</a>.</p>
 
 <h3>Keynote</h3>
 <ol>
@@ -28,5 +28,5 @@ title: Presentation themes
 	<li>Open the <strong>18F_Template_2016-03-29.key</strong> file.</li>
 	<li>In the <strong>File</strong> menu, click <strong>Save Theme…</strong> and click <strong>Add to Theme Chooser</strong>.</li>
 </ol>
-<p>To start a new presentation with the template, press the <strong>Command + N</strong> keys, click <strong>My Templates</strong>, and choose the 18F template. For more details, learn about <a href="https://help.apple.com/keynote/mac/6.6/#/tan584189747">changing the look and layout of slides</a>.
+<p>To start a new presentation with the template, press <strong>Command + N</strong>, click <strong>My Templates</strong>, and choose the 18F template. For more details, learn about <a href="https://help.apple.com/keynote/mac/6.6/#/tan584189747">changing the look and layout of slides</a>.
 </p>

--- a/pages/presentation-themes.html
+++ b/pages/presentation-themes.html
@@ -24,7 +24,7 @@ title: Presentation themes
 
 <h3>Keynote</h3>
 <ol>
-	<li>Follow the <a href="{{ site.baseurl }}/typography.html">instructions to install 18F Nimbus</a>.</li>
+	<li>Follow the <a href="{{ site.baseurl }}/typography/">instructions to install 18F Nimbus</a>.</li>
 	<li>Open the <strong>18F_Template_2016-03-29.key</strong> file.</li>
 	<li>In the <strong>File</strong> menu, click <strong>Save Theme…</strong> and click <strong>Add to Theme Chooser</strong>.</li>
 </ol>

--- a/pages/presentation-themes.html
+++ b/pages/presentation-themes.html
@@ -7,7 +7,7 @@ title: Presentation themes
 <p>Templates for Google Slides and Keynote</p>
 
 <img src="{{ site.baseurl }}/assets/img/Template_Preview.png">
-
+<br><br>
 <a class="usa-button usa-button-gray" href="https://docs.google.com/presentation/d/1AtTYOd0jjZnKUhBQ0c5oX5mmHQ4bd_Q2KvrdsQMw2nk/edit#slide=id.g1442ff0c3e_1_7">Google Slides template</a>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Keynote.zip">Download Keynote template and fonts</a>
 

--- a/pages/presentation-themes.html
+++ b/pages/presentation-themes.html
@@ -4,20 +4,29 @@ layout: default
 title: Presentation themes
 ---
 
-<p>Quick start reference guide for using 18F brand assets, including:</p>
-<ul>
-	<li>Logo usage</li>
-	<li>How to install the brand colors on your mac</li>
-	<li>Using our brand font</li>
-	<li>Keynote theme instructions</li>
-	<li>How to use the Google Slides template</li>
-</ul>
-<img src="{{ site.baseurl }}/assets/img/Instructions_Preview.png">
-<br><br>
-<a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/Using_18Fs_Templates.pdf">Download instructions</a>
+<p>Templates for Google Slides and Keynote</p>
 
-<p>Download the keynote presentation template with sample layouts and fonts, or use the Google Slides version if you prefer. (If an error prompt appears on opening the Keynote template, install the provided fonts.)</p>
 <img src="{{ site.baseurl }}/assets/img/Template_Preview.png">
-<br><br>
+
 <a class="usa-button usa-button-gray" href="https://docs.google.com/presentation/d/1AtTYOd0jjZnKUhBQ0c5oX5mmHQ4bd_Q2KvrdsQMw2nk/edit#slide=id.g1442ff0c3e_1_7">Google Slides template</a>
-<a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Keynote.zip">Download keynote template and fonts</a>
+<a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Keynote.zip">Download Keynote template and fonts</a>
+
+<h2>Instructions</h2>
+<h3>Google Slides</h3>
+<ol>
+	<li>In Google Drive, click <strong>New > Google Slides</strong>.</li>
+	<li>Once a new presentation opens, choose the <strong>Theme</strong> button in the toolbar.</li>
+	<li>Click <strong>Import theme</strong> at the bottom of the theme menu.</li>
+	<li>Search for <strong>18F_Theme_GoogleSlides</strong>.</li>
+	<li>Select and import the theme.</li>
+</ol>
+<p>When using the 18F template, you can choose different layouts by selecting and inserting master pages. For more details, learn about <a href="https://support.google.com/docs/answer/1694986?hl=en">custom layouts and themes</a>.</p>
+
+<h3>Keynote</h3>
+<ol>
+	<li>Follow the <a href="{{ site.baseurl }}/typography.html">instructions to install 18F Nimbus</a>.</li>
+	<li>Open the <strong>18F_Template_2016-03-29.key</strong> file.</li>
+	<li>In the <strong>File</strong> menu, click <strong>Save Theme…</strong> and click <strong>Add to Theme Chooser</strong>.</li>
+</ol>
+<p>To start a new presentation with the template, press the <strong>Command + N</strong> keys, click <strong>My Templates</strong>, and choose the 18F template. For more details, learn about <a href="https://help.apple.com/keynote/mac/6.6/#/tan584189747">changing the look and layout of slides</a>.
+</p>

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -21,4 +21,4 @@ title: Typography
 			Drag the files to the <strong>Font Book</strong> icon in your dock.
 		</li>
 	</ol>
-<p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple’s guide to using paragraph styles</a>. In Google Slides, use Helvetica Neue.</p>
+<p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple&rsquo;s guide to using paragraph styles</a>. In Google Slides, use Helvetica Neue.</p>

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -4,5 +4,21 @@ layout: default
 title: Typography
 ---
 
-<p>18F Nimbus Sans – Regular, Italic, Bold (TTF)</p>
+<p>Nimbus 18F – Regular, Italic, Bold (TTF)</p>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Nimbus.zip">Download fonts</a>
+
+<p>Nimbus 18F was created in 2016. It is based on <a href="http://www.fontain.org/nimbus-sans-l/">Nimbus Sans L</a>, originally created by URW++, and is distributed under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License</a>.</p>
+
+<h2>Instructions</h2>
+	<ol>
+		<li>
+			Open <strong>Font Book</strong>.
+		</li>
+		<li>
+			In the <strong>18F_Nimbus</strong> folder, press the <strong>Command + A</strong> keys to select the font files.
+		</li>
+		<li>
+			Drag the files to the <strong>Font Book</strong> icon in your dock.
+		</li>
+	</ol>
+<p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple’s guide to using paragraph styles</a>. In Google Slides, use Helvetica Neue.</p>


### PR DESCRIPTION
## Changes:
- Repositions the copy throughout the site to acknowledge readers from outside of 18F in preparation for moving off staging https://github.com/18F/brand/issues/83
- Brings content in line with the 18F Content Guide recommendations
- Moves Instructions and Guidelines for use out of PDFs and directly on the page. 
  - Resolves https://github.com/18F/brand/issues/85
- Removes one desktop art image that we couldn't find the citation for
- Incorporates licensing info on custom fonts h/t @thisisdano 
- Small changes to link styling, including:
  - Removing the visual difference between visited and not-yet-visited links
  - Making links in lists the same style as links out of lists. Previously links inside lists did not have underlines

## Review:
@nicoleslaw to review my implementation of her formatting

## Comments

These copy changes pointed out a small flaw in the main body container size, where items formatted in a `ul` or `ol` break out of the container width being used by paragraph copy. I couldn't find an obvious place to fix this, and it isn't critical to this priority, or otherwise heinously ugly, so would like to create a follow-up PR on another branch later, maybe with @maya 's help?

Here's what I mean:

<img width="697" alt="screen shot 2016-07-15 at 11 00 21 am" src="https://cloud.githubusercontent.com/assets/11636908/16878654/699a989c-4a7b-11e6-80a8-6ff9925c6e8b.png">

<img width="972" alt="screen shot 2016-07-15 at 11 00 35 am" src="https://cloud.githubusercontent.com/assets/11636908/16878653/6998e7c2-4a7b-11e6-9322-30080d4ae777.png">
