### PR TITLE
Type specimens for typography page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+.DS_Store
+

--- a/_sass/_styleguide.scss
+++ b/_sass/_styleguide.scss
@@ -448,6 +448,13 @@ h1, h2, h3, h4, h5, h6 {
   font-family: $font-sans;
 }
 
+//  rewrote this to prevent overlapping margins
+
+h4 {
+  margin-top: 0;
+  padding-top: 1.5em;
+}
+
 a {
   color: $color-medium;
   text-decoration: underline;
@@ -488,7 +495,7 @@ a {
     margin-top: 0;
   }
 }
-.typography-sans-intro {
+.typography-specimen {
   .text-huge {
     font-size: 140px;
     line-height: 1.05;
@@ -497,13 +504,7 @@ a {
     font-size: 15px;
   }
 }
-.typography-serif-intro {
-  .text-huge {
-    font-size: 120px;
-    line-height: 1.275;
-  }
-  .text-tiny {
-    font-size: 13px;
-  }
-}
 
+.bold {
+  font-weight: bold; 
+}

--- a/_sass/_styleguide.scss
+++ b/_sass/_styleguide.scss
@@ -479,3 +479,31 @@ a {
 .display-logo {
   max-width: 162px;
 }
+
+// added from USWDS for typography section
+
+.text-tiny {
+  @include margin(5px null 0);
+  &:first-child {
+    margin-top: 0;
+  }
+}
+.typography-sans-intro {
+  .text-huge {
+    font-size: 140px;
+    line-height: 1.05;
+  }
+  .text-tiny {
+    font-size: 15px;
+  }
+}
+.typography-serif-intro {
+  .text-huge {
+    font-size: 120px;
+    line-height: 1.275;
+  }
+  .text-tiny {
+    font-size: 13px;
+  }
+}
+

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -12,7 +12,7 @@ title: Typography
     <p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple&rsquo;s guide to using paragraph styles</a>.</p>
 
   <div class="typography-specimen usa-width-one-half usa-end-row">
-  <h4 class="usa-heading-alt">Helvetica Neue, Regular</h4>
+  <h4>Helvetica Neue, Regular</h4>
     <span class="text-huge">Aa</span>
     <div>
       <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
@@ -22,7 +22,7 @@ title: Typography
   </div>
 
   <div class="typography-specimen usa-width-one-half usa-end-row bold">
-  <h4 class="usa-heading-alt">Helvetica Neue, Bold</h4>
+  <h4>Helvetica Neue, Bold</h4>
     <span class="text-huge">Aa</span>
     <div>
       <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -12,7 +12,7 @@ title: Typography
 
 <p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple&rsquo;s guide to using paragraph styles</a>.</p>
 
-<h4 class="usa-heading-alt">Source Sans Pro</h4>
+<h4 class="usa-heading-alt">Helvetica Neue Regular</h4>
 
 <div class="usa-grid-full">
   <div class="usa-width-one-half">
@@ -20,7 +20,7 @@ title: Typography
     <p>Inspired by twentieth-century American gothic typeface design, its slender but open letters offer a clean and friendly simplicity. Advanced hinting allows Source Sans Pro to render well on Windows systems which run Cleartype, and across browsers and devices. Moreover, it supports a variety of languages and alphabets, including Western and European language, Vietnamese, pinyin Romanization of Chinese, and Navajo.</p>
   </div>
 
-  <div class="typography-sans-intro usa-width-one-half usa-end-row">
+  <div class="typography-specimen usa-width-one-half usa-end-row">
     <span class="text-huge">Aa</span>
     <div>
       <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
@@ -30,7 +30,7 @@ title: Typography
   </div>
 </div>
 
-<h4 class="usa-heading-alt">Merriweather</h4>
+<h4 class="usa-heading-alt">Helvetica Neue Bold</h4>
 
 <div class="usa-grid-full">
   <div class="usa-width-one-half">
@@ -38,7 +38,7 @@ title: Typography
     <p>The combination of slim and thick weights gives the font family stylistic range, while conveying a desirable mix of classic, yet modern simplicity. Merriweather communicates warmth and credibility at both large and smaller font sizes.</p>
   </div>
 
-  <div class="typography-serif-intro usa-width-one-half usa-end-row usa-serif">
+  <div class="typography-specimen usa-width-one-half usa-end-row bold">
     <span class="text-huge">Aa</span>
     <div>
       <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -4,23 +4,15 @@ layout: default
 title: Typography
 ---
 
-<p>The primary font is <strong>Helvetica Neue</strong>, in bold and regular weights.</p>
-
-<p>We use one typeface to keep things simple, and use variations in size and weight to create hierarchy.</p> 
-
-<p>Helvetica Neue is a system font on all Apple devices, so you don't need to download or install anything. On Windows devices, if Helvetica Neue is not available, use Arial as a replacement.</p>
-
-<p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple&rsquo;s guide to using paragraph styles</a>.</p>
-
-<h4 class="usa-heading-alt">Helvetica Neue Regular</h4>
 
 <div class="usa-grid-full">
-  <div class="usa-width-one-half">
-    <p>Source Sans Pro is an open-source sans serif typeface created for legibility in UI design. With a variety of weights that read easily at all sizes, Source Sans Pro provides clear headers as well as highly-readable body text.</p>
-    <p>Inspired by twentieth-century American gothic typeface design, its slender but open letters offer a clean and friendly simplicity. Advanced hinting allows Source Sans Pro to render well on Windows systems which run Cleartype, and across browsers and devices. Moreover, it supports a variety of languages and alphabets, including Western and European language, Vietnamese, pinyin Romanization of Chinese, and Navajo.</p>
-  </div>
+    <p>The primary font is <strong>Helvetica Neue</strong>, in bold and regular weights.</p>
+    <p>We use one typeface to keep things simple, and use different font sizes and weights to create hierarchy.</p> 
+    <p>Helvetica Neue is a system font on all Apple devices, so you don't need to download or install anything. On Windows devices, if Helvetica Neue is not available, use Arial as a replacement.</p>
+    <p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple&rsquo;s guide to using paragraph styles</a>.</p>
 
   <div class="typography-specimen usa-width-one-half usa-end-row">
+  <h4 class="usa-heading-alt">Helvetica Neue, Regular</h4>
     <span class="text-huge">Aa</span>
     <div>
       <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
@@ -28,17 +20,9 @@ title: Typography
       <p class="text-tiny">0 1 2 3 4 5 6 7 8 9</p>
     </div>
   </div>
-</div>
-
-<h4 class="usa-heading-alt">Helvetica Neue Bold</h4>
-
-<div class="usa-grid-full">
-  <div class="usa-width-one-half">
-    <p>Merriweather is an open-source serif typeface designed for on-screen reading. This font is ideal for text-dense design: the letterforms have a tall x-height but remain relatively small, making for excellent readability across screen sizes while not occupying extra horizontal space.</p>
-    <p>The combination of slim and thick weights gives the font family stylistic range, while conveying a desirable mix of classic, yet modern simplicity. Merriweather communicates warmth and credibility at both large and smaller font sizes.</p>
-  </div>
 
   <div class="typography-specimen usa-width-one-half usa-end-row bold">
+  <h4 class="usa-heading-alt">Helvetica Neue, Bold</h4>
     <span class="text-huge">Aa</span>
     <div>
       <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -11,3 +11,39 @@ title: Typography
 <p>Helvetica Neue is a system font on all Apple devices, so you don't need to download or install anything. On Windows devices, if Helvetica Neue is not available, use Arial as a replacement.</p>
 
 <p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple&rsquo;s guide to using paragraph styles</a>.</p>
+
+<h4 class="usa-heading-alt">Source Sans Pro</h4>
+
+<div class="usa-grid-full">
+  <div class="usa-width-one-half">
+    <p>Source Sans Pro is an open-source sans serif typeface created for legibility in UI design. With a variety of weights that read easily at all sizes, Source Sans Pro provides clear headers as well as highly-readable body text.</p>
+    <p>Inspired by twentieth-century American gothic typeface design, its slender but open letters offer a clean and friendly simplicity. Advanced hinting allows Source Sans Pro to render well on Windows systems which run Cleartype, and across browsers and devices. Moreover, it supports a variety of languages and alphabets, including Western and European language, Vietnamese, pinyin Romanization of Chinese, and Navajo.</p>
+  </div>
+
+  <div class="typography-sans-intro usa-width-one-half usa-end-row">
+    <span class="text-huge">Aa</span>
+    <div>
+      <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+      <p class="text-tiny">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="text-tiny">0 1 2 3 4 5 6 7 8 9</p>
+    </div>
+  </div>
+</div>
+
+<h4 class="usa-heading-alt">Merriweather</h4>
+
+<div class="usa-grid-full">
+  <div class="usa-width-one-half">
+    <p>Merriweather is an open-source serif typeface designed for on-screen reading. This font is ideal for text-dense design: the letterforms have a tall x-height but remain relatively small, making for excellent readability across screen sizes while not occupying extra horizontal space.</p>
+    <p>The combination of slim and thick weights gives the font family stylistic range, while conveying a desirable mix of classic, yet modern simplicity. Merriweather communicates warmth and credibility at both large and smaller font sizes.</p>
+  </div>
+
+  <div class="typography-serif-intro usa-width-one-half usa-end-row usa-serif">
+    <span class="text-huge">Aa</span>
+    <div>
+      <p class="text-tiny">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+      <p class="text-tiny">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="text-tiny">0 1 2 3 4 5 6 7 8 9</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Added type specimens to the typography page and tweaked the styles to make it all look right. Pretty much copied the USWDS page here: https://standards.usa.gov/typography/

- - -

<img width="874" alt="screen shot 2016-09-27 at 8 55 23 am" src="https://cloud.githubusercontent.com/assets/11464021/18881454/2ce2a076-8490-11e6-8593-d63ce1ca5145.png">
