### PR TITLE
Creates template section

### DIFF
--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -16,7 +16,7 @@
         <a {% if current[1] == 'typography' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/typography/">Typography</a>
       </li>
       <li>
-        <a {% if current[1] == 'presentation-themes' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/presentation-themes/">Presentation <br>themes</a>
+        <a {% if current[1] == 'templates' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/templates/">Templates</a>
       </li>
       <li>
         <a {% if current[1] == 'desktop-art' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/desktop-art/">Desktop art</a>

--- a/pages/color-palette.html
+++ b/pages/color-palette.html
@@ -20,7 +20,7 @@ title: Color palette
 
 <br>
 
-<h2>Instructions for Keynote</h2>
+<h3>Instructions for Keynote</h3>
 <p>Install the color palette to use it in any iWork application:</p>
 	<ol>
 		<li>

--- a/pages/desktop-art.html
+++ b/pages/desktop-art.html
@@ -9,7 +9,7 @@ title: Desktop art
 <br><br>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Desktop_Art.zip">Download desktop art</a>
 
-<h2>Instructions</h2>
+<h3>Instructions</h3>
 <ol>
 	<li>In <strong>System Preferences</strong>, open <strong>Desktop &amp; Screensaver</strong>.</li>
 	<li>On the <strong>Desktop</strong> tab, click the <strong>+</strong> button.</li>
@@ -17,7 +17,7 @@ title: Desktop art
 	<li>Choose your desktop wallpaper on the right.</li>
 </ol>
 
-<h3>Image credits</h3>
+<h4>Image credits</h4>
 <ul>
 	<li>Flag, <a href="https://unsplash.com/photos/xn4Lc-87_fM">Eric Duvauchelle</a></li>
 	<li>Sky, <a href="http://tumblr.unsplash.com/post/54230079634/download-tumprins">Tumprins</a></li>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -3,7 +3,7 @@ permalink: /templates/
 layout: default
 title: Templates
 ---
-<h2>Google Docs template</h2>
+<h2>Google Docs templates</h2>
 <p>We have two Google Docs templates: a <a href="#">basic outline</a> and a <a href="#">detailed report example</a> with a table of contents, tables, typographic elements, and an appendix. While both of these templates are branded for 18F, anyone in TTS can use them.</p>
 <h3>Instructions</h3>
 <h4>To save 18F styles as your default Google styles:</h4>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -1,7 +1,7 @@
 ---
-permalink: /presentation-themes/
+permalink: /templates/
 layout: default
-title: Presentation themes
+title: templates
 ---
 
 <p>For Google Slides and Keynote</p>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -6,14 +6,14 @@ title: Templates
 <h2>Google Docs template</h2>
 <p>We have two Google Docs templates: a <a href="#">basic outline</a> and a <a href="#">detailed report example</a> with a table of contents, tables, typographic elements, and an appendix. While both of these templates are branded for 18F, anyone in TTS can use them.</p>
 <h3>Instructions</h3>
-<p>To save 18F styles as your default Google styles:</p>
+<h4>To save 18F styles as your default Google styles:</h4>
 <ol>
 	<li>Open the <a href="#">basic outline</a>.</li>
 	<li>In the Styles drop-down menu, choose <strong>Options > Save as my default styles</strong>.</li>
 	<li>Click <strong>File > New > Document</strong> or open an existing document to apply the 18F styles to it.</li>
 	<li>In the Styles drop-down menu, choose <strong>Options > Use my default styles</strong>.</li>
 </ol>
-<p>To reuse specific tables or typographic elements in a Google Doc:</p>
+<h4>To reuse specific tables or typographic elements in a Google Doc:</h4>
 <ol>
 	<li>Open the <a href="#">detailed report example</a>.</li>
 	<li>Click <strong>File > Make a copy…</strong> (This will ensure you don’t accidentally edit the original master file.)</li>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -1,18 +1,35 @@
 ---
 permalink: /templates/
 layout: default
-title: templates
+title: Templates
 ---
-
-<p>For Google Slides and Keynote</p>
+<h2>Google Docs template</h2>
+<p>We have two Google Docs templates: a <a href="#">basic outline</a> and a <a href="#">detailed report example</a> with a table of contents, tables, typographic elements, and an appendix. While both of these templates are branded for 18F, anyone in TTS can use them.</p>
+<h3>Instructions</h3>
+<p>To save 18F styles as your default Google styles:</p>
+<ol>
+	<li>Open the <a href="#">basic outline</a>.</li>
+	<li>In the Styles drop-down menu, choose <strong>Options > Save as my default styles</strong>.</li>
+	<li>Click <strong>File > New > Document</strong> or open an existing document to apply the 18F styles to it.</li>
+	<li>In the Styles drop-down menu, choose <strong>Options > Use my default styles</strong>.</li>
+</ol>
+<p>To reuse specific tables or typographic elements in a Google Doc:</p>
+<ol>
+	<li>Open the <a href="#">detailed report example</a>.</li>
+	<li>Click <strong>File > Make a copy…</strong> (This will ensure you don’t accidentally edit the original master file.)</li>
+	<li>Highlight and delete any sections you don’t need, and make changes as needed.</li>
+</ol>
+<br>
+<hr>
+<h2>Presentation templates for Google Slides and Keynote</h2>
 
 <img src="{{ site.baseurl }}/assets/img/Template_Preview.png">
 <br><br>
 <a class="usa-button usa-button-gray" href="https://docs.google.com/presentation/d/1AtTYOd0jjZnKUhBQ0c5oX5mmHQ4bd_Q2KvrdsQMw2nk/edit#slide=id.g1442ff0c3e_1_7">Google Slides template</a>
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Keynote.zip">Download Keynote template</a>
 
-<h2>Instructions</h2>
-<h3>Google Slides</h3>
+<h3>Instructions</h3>
+<h4>Google Slides</h4>
 <ol>
 	<li>In Google Drive, click <strong>New > Google Slides</strong>.</li>
 	<li>Once a new presentation opens, choose the <strong>Theme</strong> button in the toolbar.</li>
@@ -22,7 +39,7 @@ title: templates
 </ol>
 <p>You can choose different layouts by selecting and inserting master pages from the template. For more details, learn about <a href="https://support.google.com/docs/answer/1694986?hl=en">custom layouts and themes</a>.</p>
 
-<h3>Keynote</h3>
+<h4>Keynote</h4>
 <ol>
 	<li>Open the <strong>18F_Template_2016-09-15.key</strong> file.</li>
 	<li>In the <strong>File</strong> menu, click <strong>Save Theme…</strong> and click <strong>Add to Theme Chooser</strong>.</li>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -4,18 +4,18 @@ layout: default
 title: Templates
 ---
 <h2>Google Docs templates</h2>
-<p>We have two Google Docs templates: a <a href="#">basic outline</a> and a <a href="#">detailed report example</a> with a table of contents, tables, typographic elements, and an appendix. While both of these templates are branded for 18F, anyone in TTS can use them.</p>
+<p>We have two Google Docs templates: a <a href="https://docs.google.com/a/gsa.gov/document/d/1lJBCZwgQzKsX5ggr7ykUaeuAUNqKsthENYCXMTA5Tbs/edit?usp=sharing">basic outline</a> and a <a href="https://docs.google.com/a/gsa.gov/document/d/1BovRM6thz0YWCyd32zwbh-6TYy4ON6GEc8ILDd3RLl8/edit?usp=sharing">detailed example</a> with a table of contents, tables, typographic elements, and an appendix. While both of these templates are branded for 18F, anyone in TTS can use them.</p>
 <h3>Instructions</h3>
 <h4>To save 18F styles as your default Google styles:</h4>
 <ol>
-	<li>Open the <a href="#">basic outline</a>.</li>
+	<li>Open the <a href="https://docs.google.com/a/gsa.gov/document/d/1lJBCZwgQzKsX5ggr7ykUaeuAUNqKsthENYCXMTA5Tbs/edit?usp=sharing">basic outline</a>.</li>
 	<li>In the Styles drop-down menu, choose <strong>Options > Save as my default styles</strong>.</li>
 	<li>Click <strong>File > New > Document</strong> or open an existing document to apply the 18F styles to it.</li>
 	<li>In the Styles drop-down menu, choose <strong>Options > Use my default styles</strong>.</li>
 </ol>
 <h4>To reuse specific tables or typographic elements in a Google Doc:</h4>
 <ol>
-	<li>Open the <a href="#">detailed report example</a>.</li>
+	<li>Open the <a href="https://docs.google.com/a/gsa.gov/document/d/1BovRM6thz0YWCyd32zwbh-6TYy4ON6GEc8ILDd3RLl8/edit?usp=sharing">detailed example</a>.</li>
 	<li>Click <strong>File > Make a copy…</strong> (This will ensure you don’t accidentally edit the original master file.)</li>
 	<li>Highlight and delete any sections you don’t need, and make changes as needed.</li>
 </ol>


### PR DESCRIPTION
## Summary
This begins completion criteria for https://github.com/18F/visual-design/issues/27#issuecomment-293404713
- Changes "Presentation themes" page to "Templates" page to be more inclusive 
- Adds front content for Google Doc template
- Makes font hierarchy consistent across other sections, especially applied to "Instructions" as an `h3` instead of an `h2`

## Remaining tasks

- [x] Get final share links for Google Docs

## Preview
(Ignore the duplicated side nav which is an artifact of my screen shot tool)
![screencapture-127-0-0-1-4000-templates-1491948397800](https://cloud.githubusercontent.com/assets/11636908/24932925/c47123cc-1ee1-11e7-95da-c0e998bd8673.png)

cc @amberwreed and @austinhernandez for visibility
