### PR TITLE
Fix broken link

### DIFF
--- a/pages/logo.html
+++ b/pages/logo.html
@@ -12,7 +12,7 @@ title: Logo
 <h2>Guidelines</h2>
 <ul>
 	<li>
-		<strong>Do</strong> use the black version of the logo over a white background as your default. Bright blue (#00cfff) and white do not have enough contrast to meet accessibility requirements for low-vision users. Even though logos can be an exception to this rule, we prefer to follow best practices, and use black as our primary logo color. The bright blue version of the logo should only be used if you are using a dark page background. You can see an example of this in our <a href="{{ site.baseurl }}/presentation-themes/">presentation themes</a>.
+		<strong>Do</strong> use the black version of the logo over a white background as your default. Bright blue (#00cfff) and white do not have enough contrast to meet accessibility requirements for low-vision users. Even though logos can be an exception to this rule, we prefer to follow best practices, and use black as our primary logo color. The bright blue version of the logo should only be used if you are using a dark page background. You can see an example of this in our <a href="{{ site.baseurl }}/templates/">presentation templates</a>.
 	</li>
 	<li>
 		<strong>Do</strong> keep adequate white space around the logo. At any size, there should be half a logo&rsquo;s-width of white space between the logo and any other object or border.


### PR DESCRIPTION
Link has a 404 error.

New link correctly goes to template page which has light-blue 18F logo