### PR TITLE
Add principles to site

### DIFF
--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -21,6 +21,9 @@
       <li>
         <a {% if current[1] == 'desktop-art' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/desktop-art/">Desktop art</a>
       </li>
+      <li>
+        <a {% if current[1] == 'principles' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/principles/">Principles</a>
+      </li>
     </ul>
   </nav>
 </aside>

--- a/pages/principles.html
+++ b/pages/principles.html
@@ -4,7 +4,7 @@ layout: default
 title: Visual design principles
 ---
 
-<p>The purpose of visual design principles is to provide guidance for applying and extending the 18F identity into other communication assets. They serve as a framework for evaluating potential design solutions against our core values and priorities.</p>
+<p>These visual design principles provide guidance for applying and extending the 18F identity into other communication assets. They serve as a framework for evaluating potential design solutions against our core values and priorities.</p>
 <p>18F's visual design principles are intended to be applied to projects that should reflect the 18F brand, not work we do for our partners.</p>
 
 <h2>Lead by example</h2>

--- a/pages/principles.html
+++ b/pages/principles.html
@@ -14,7 +14,7 @@ title: Visual design principles
 	<li>How would you feel if this design was repeated across 18F or government?</li>
 </ul>
 
-<h2>Lead by example</h2>
+<h2>Let the content be the voice</h2>
 <p>Bring clarity to content through design choices that support meaning and intent. Design a fair, inclusive, and open platform for the many voices that make up 18F.</p>
 <ul>
 	<li>Do the visuals overpower the content?</li>

--- a/pages/principles.html
+++ b/pages/principles.html
@@ -1,0 +1,58 @@
+---
+permalink: /principles/
+layout: default
+title: Visual design principles
+---
+
+<p>The purpose of visual design principles is to provide guidance for applying and extending the 18F identity into other communication assets. They serve as a framework for evaluating potential design solutions against our core values and priorities.</p>
+<p>18F's visual design principles are intended to be applied to projects that should reflect the 18F brand, not work we do for our partners.</p>
+
+<h2>Lead by example</h2>
+<p>You’re a role model. Don’t do anything you wouldn’t encourage others to copy.</p>
+<ul>
+	<li>Is this design an example of best practices? If not, is it a modification you believe others should consider a best practice?</li>
+	<li>How would you feel if this design was repeated across 18F or government?</li>
+</ul>
+
+<h2>Lead by example</h2>
+<p>Bring clarity to content through design choices that support meaning and intent. Design a fair, inclusive, and open platform for the many voices that make up 18F.</p>
+<ul>
+	<li>Do the visuals overpower the content?</li>
+	<li>Do the design choices promote clarity of meaning?</li>
+	<li>What message does the design convey before you read the words?</li>
+	<li>How does typographic hierarchy contribute to understanding?</li>
+	<li>Does the content design allow for multiple levels of engagement?</li>
+</ul>
+
+<h2>Start with the expected</h2>
+<p>Meet expectations before you raise them. Favor solutions from standards. Use common design patterns that establish confidence and trust. Don’t reinvent the wheel, incrementally improve it.</p>
+<ul>
+	<li>Are you using a commonly used pattern?</li>
+	<li>Has someone else solved this problem already?</li>
+	<li>What is the potential benefit of an unconventional solution?</li>
+	<li>Could your modifications be applied back to a standard?</li>
+	<li>Are the unique elements of the design necessary? Could an existing element be used instead?</li>
+	<li>Is the reason for design choices apparent?</li>
+	<li>Does your design feel part of a considered visual system?</li>
+</ul>
+
+<h2>Convince with soundness not loudness</h2>
+<p>Design with confidence and calmness by being honest and direct. Practice visual design with solid fundamentals, attention to detail, flexibility, and resilience.</p>
+<ul>
+	<li>Is the layout of elements intuitive?</li>
+	<li>Does the design guide the viewer?</li>
+	<li>Are you leveraging typographic styles?</li>
+	<li>Are there elements that get in the way of understanding?</li>
+	<li>Have you run spell check lately?</li>
+	<li>Is the tone honest, respectful, and inviting?</li>
+	<li>Does it exceed expectations for government?</li>
+</ul>
+
+<h2>Keep questioning</h2>
+<p>Have opinions, express them, and be open to change. Question the principles — acknowledge their dynamic, iterative nature. Evolve alongside 18F’s people, culture, and core values. Push forward.</p>
+<ul>
+	<li>Is something missing? Is this an opportunity for the principles to grow?</li>
+	<li>Are these principles consistent with 18F’s organizational principles?</li>
+	<li>Do the decisions encouraged by these principles result in the desired outcomes for the folks using what we design?</li>
+	<li>Have you discussed any dissatisfaction with the principles with anyone? Why not?</li>
+</ul>


### PR DESCRIPTION
## Summary
Adds visual design principles for 18F to the visual identity guide site.

😎 [PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/brand/principles/principles/)


## Background 
[A long long time ago](https://github.com/18F/visual-design/issues/32) @amberwreed & @thisisdano facilitated the team to develop visual design principles that applied to 18F's visual identity work. 

We meant to add them to this site, but after folks left 18F or moved to other parts of the org, they got parked in the wiki instead: https://github.com/18F/brand/wiki/18F-Brand-visual-design-principles-(draft). With @alexsoble 's help I finally got past the Ruby errors that were preventing me from running the site locally, and now HERE THEY ARE!

As a follow up to this PR, we should remove them from the wiki so that information only lives in one place. 

