### PR TITLE
Update slide template links

### DIFF
--- a/pages/color-palette.html
+++ b/pages/color-palette.html
@@ -20,7 +20,7 @@ title: Color palette
 
 <br>
 
-<h3>Instructions for Keynote</h3>
+<h3>Instructions for Mac applications</h3>
 <p>Install the color palette to use it in any iWork application:</p>
 	<ol>
 		<li>

--- a/pages/color-palette.html
+++ b/pages/color-palette.html
@@ -20,25 +20,6 @@ title: Color palette
 
 <br>
 
-<h3>Instructions for Mac applications</h3>
-<p>Install the color palette to use it in any iWork application:</p>
-	<ol>
-		<li>
-			Open the <strong>18F_Color_Palette.zip</strong> file to unzip it.
-		</li>
-		<li>
-			In Keynote, press the <strong>Shift + Command + C</strong> keys to open the Colors menu.
-		</li>
-		<li>
-			Click the <strong>Color Palettes</strong> tab.
-		</li>
-		<li>
-			Click the <strong>gear icon > Open…</strong>
-		</li>
-		<li>
-			In the <strong>18F_Color_Palette</strong> folder, select <strong>18F_brand_colors.clr</strong> and click <strong>Open</strong>.
-		</li>
-	</ol>
 
 <h2>Guidelines</h2>
 <p><strong>Do</strong> use the 18F brand colors in combinations that conform with accessibility standards. Each of these combinations meets or exceeds a contrast ratio of 4.5:1, and is approved for body and headline text. For more details on color contrast, read the <a href="https://pages.18f.gov/accessibility/">18F Accessibility Guide</a>.</p>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -21,7 +21,7 @@ title: Templates
 </ol>
 <br>
 <hr>
-<h2>Presentation templates for Google Slides</h2>
+<h2>Google Slides presentation templates</h2>
 
 <img src="{{ site.baseurl }}/assets/img/Template_Preview.png">
 <br><br>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -29,12 +29,18 @@ title: Templates
 <a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Keynote.zip">Download Keynote template</a>
 
 <h3>Instructions</h3>
-<h4>Google Slides</h4>
+<h4>To make a new Google Slides presentation</h4>
 <ol>
-	<li>In Google Drive, click <strong>New > Google Slides</strong>.</li>
-	<li>Once a new presentation opens, choose the <strong>Theme</strong> button in the toolbar.</li>
-	<li>Click <strong>Import theme</strong> at the bottom of the theme menu.</li>
-	<li>Search for <strong>18F_Theme_GoogleSlides</strong>.</li>
+	<li>In Google Drive, click <strong>New > Google Slides > From a template</strong>.</li>
+	<li>Once the GSA Template Gallery opens, choose the <strong>18F Slide Theme_MASTER</strong> presentation from the list.</li>
+	<li>This will create a copy of the template. Rename your presentation so that the team doesn't confuse it with the original.</li>
+</ol>
+<h4>To import the theme into an existing Google Slides presentation</h4>
+<ol>
+	<li>Open your existing presentation.</li>
+	<li>Choose the <strong>Theme</strong> button in the toolbar.
+	<li>Click <strong>Import theme</strong> at the bottom of the theme menu.
+	<li>Search for <strong>18F Slide Theme_Master</strong>.</li>
 	<li>Select and import the theme.</li>
 </ol>
 <p>You can choose different layouts by selecting and inserting master pages from the template. For more details, learn about <a href="https://support.google.com/docs/answer/1694986?hl=en">custom layouts and themes</a>.</p>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -25,7 +25,7 @@ title: Templates
 
 <img src="{{ site.baseurl }}/assets/img/Template_Preview.png">
 <br><br>
-<a class="usa-button usa-button-gray" href="https://docs.google.com/presentation/d/1AtTYOd0jjZnKUhBQ0c5oX5mmHQ4bd_Q2KvrdsQMw2nk/edit#slide=id.g1442ff0c3e_1_7">Google Slides template</a>
+<a class="usa-button usa-button-gray" href="https://docs.google.com/presentation/u/0/?ftv=1&folder=0BwWYNZcEDfwabE13dnZpbFN5QmM&tgif=d">GSA slide template gallery</a>
 
 
 <h3>Instructions</h3>

--- a/pages/templates.html
+++ b/pages/templates.html
@@ -21,12 +21,12 @@ title: Templates
 </ol>
 <br>
 <hr>
-<h2>Presentation templates for Google Slides and Keynote</h2>
+<h2>Presentation templates for Google Slides</h2>
 
 <img src="{{ site.baseurl }}/assets/img/Template_Preview.png">
 <br><br>
 <a class="usa-button usa-button-gray" href="https://docs.google.com/presentation/d/1AtTYOd0jjZnKUhBQ0c5oX5mmHQ4bd_Q2KvrdsQMw2nk/edit#slide=id.g1442ff0c3e_1_7">Google Slides template</a>
-<a class="usa-button usa-button-gray" href="{{ site.baseurl }}/assets/dist/18F_Keynote.zip">Download Keynote template</a>
+
 
 <h3>Instructions</h3>
 <h4>To make a new Google Slides presentation</h4>
@@ -44,11 +44,3 @@ title: Templates
 	<li>Select and import the theme.</li>
 </ol>
 <p>You can choose different layouts by selecting and inserting master pages from the template. For more details, learn about <a href="https://support.google.com/docs/answer/1694986?hl=en">custom layouts and themes</a>.</p>
-
-<h4>Keynote</h4>
-<ol>
-	<li>Open the <strong>18F_Template_2016-09-15.key</strong> file.</li>
-	<li>In the <strong>File</strong> menu, click <strong>Save Theme…</strong> and click <strong>Add to Theme Chooser</strong>.</li>
-</ol>
-<p>To start a new presentation with the template, press <strong>Command + N</strong>, click <strong>My Templates</strong>, and choose the 18F template. For more details, learn about <a href="https://help.apple.com/keynote/mac/6.6/#/tan584189747">changing the look and layout of slides</a>.
-</p>

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -7,9 +7,8 @@ title: Typography
 
 <div class="usa-grid-full">
     <p>The primary font is <strong>Helvetica Neue</strong>, in bold and regular weights.</p>
-    <p>We use one typeface to keep things simple, and use different font sizes and weights to create hierarchy.</p> 
+    <p>We use one typeface to keep things simple, and use different font sizes and weights to create hierarchy.</p>
     <p>Helvetica Neue is a system font on all Apple devices, so you don't need to download or install anything. On Windows devices, if Helvetica Neue is not available, use Arial as a replacement.</p>
-    <p>For help formatting text in Keynote, see <a href="https://support.apple.com/kb/PH16939?locale=en_US">Apple&rsquo;s guide to using paragraph styles</a>.</p>
 
   <div class="typography-specimen usa-width-one-half usa-end-row">
   <h4>Helvetica Neue, Regular</h4>


### PR DESCRIPTION
## Summary
- Removes support for the Keynote template and and references to it. Resolves #145 
- Updates installation instructions to include both making a presentation from scratch, and re-theming an existing presentation.
- Directs users to the GSA template gallery to select a new document instead of bringing them directly into the master template. This should help people avoid accidentally editing the master template AND reduce the number of files we need to maintain to avoid this scenario.

And a few smaller things:
- Adds a missing alt tag for the cover slide
- Removes references to keynote from other pages

😎 [PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/brand/template-links/templates/)