### PR TITLE
add a note that this only applies to GSA staff

### DIFF
--- a/pages/icons.html
+++ b/pages/icons.html
@@ -15,7 +15,7 @@ title: Icons
 <li>Minimum of 2px between elements.</li>
 
 <h2>Get the icons</h2>
-<p>You can access a set of common icons in the <a href="{{ site.baseurl }}/templates/">18F Google Slides template</a>, or <a href="{{ site.baseurl }}/assets/dist/18F_feather.zip">download the full set.</a></p>
+<p>You can access a set of common icons in the <a href="{{ site.baseurl }}/templates/">18F Google Slides template</a> (only available to GSA staff), or <a href="{{ site.baseurl }}/assets/dist/18F_feather.zip">download the full set.</a></p>
 
 <p>The download includes:</p>
 <ul>


### PR DESCRIPTION
This is so neat, but I thought at first the google slide template might be public. Adding this clarifies its not.