### PR TITLE
Adding link to 18F Avataaar resources

### DIFF
--- a/pages/icons.html
+++ b/pages/icons.html
@@ -23,3 +23,8 @@ title: Icons
 	<li>SVG and PNG exports of all icons, by color.</li>
 	<li>A sketch file of all icons for designers.</li>
 </ul>
+
+<h2>Representing humans</h2>
+<p>In order to offer more diverse and expressive ways to represent humans, we created a custom set of 18F Avataaars (based on <a href="https://getavataaars.com/">the work of Pablo Stanley</a>). These are great stand-ins for showing emotion and to represent anonymous user groups. We've started with 10 characters and a range of emotions.
+We have a <a href="https://docs.google.com/presentation/d/1CXXvxBbVjO3LjIUwRYEbk8WHpsG0AJdUc6SI_jAZDNQ/edit#slide=id.g5fdac3c814_0_209">starter deck</a>, which includes guidance on different ways to represent humans, as well as a <a href="https://drive.google.com/drive/folders/1MFGWlJ6Z1ZzIVXK0h0Xh8RsUiBZzYdbg">full sketch library< for designers (only available to GSA staff).</p>
+

--- a/pages/icons.html
+++ b/pages/icons.html
@@ -29,7 +29,7 @@ title: Icons
 
 <p>These are available to GSA staff in two formats:</p>
 <ul>
-	<li>Via the <a href="https://docs.google.com/presentation/d/1CXXvxBbVjO3LjIUwRYEbk8WHpsG0AJdUc6SI_jAZDNQ/edit#slide=id.g5fdac3c814_0_209">starter deck</a>, which includes 10 characters and a range of emotions as well as guidance on different ways to represent humans</li>
+	<li>Via the <a href="https://docs.google.com/presentation/d/1CXXvxBbVjO3LjIUwRYEbk8WHpsG0AJdUc6SI_jAZDNQ/edit#slide=id.g5fdac3c814_0_209">starter deck</a>, which includes 10 characters and a range of emotions as well as guidance on different ways to represent humans. You can also get to this starter from the <a href="{{ site.baseurl }}/templates/">18F Google Slides template</a>.</li>
 	<li>Via the <a href="https://drive.google.com/drive/folders/1MFGWlJ6Z1ZzIVXK0h0Xh8RsUiBZzYdbg">full sketch library</a> for designers.</li>
 </ul>
 

--- a/pages/icons.html
+++ b/pages/icons.html
@@ -25,6 +25,11 @@ title: Icons
 </ul>
 
 <h2>Representing humans</h2>
-<p>In order to offer more diverse and expressive ways to represent humans, we created a custom set of 18F Avataaars (based on <a href="https://getavataaars.com/">the work of Pablo Stanley</a>). These are great stand-ins for showing emotion and to represent anonymous user groups. We've started with 10 characters and a range of emotions.
-We have a <a href="https://docs.google.com/presentation/d/1CXXvxBbVjO3LjIUwRYEbk8WHpsG0AJdUc6SI_jAZDNQ/edit#slide=id.g5fdac3c814_0_209">starter deck</a>, which includes guidance on different ways to represent humans, as well as a <a href="https://drive.google.com/drive/folders/1MFGWlJ6Z1ZzIVXK0h0Xh8RsUiBZzYdbg">full sketch library< for designers (only available to GSA staff).</p>
+<p>In order to offer more diverse and expressive ways to represent humans, we created a custom set of 18F Avataaars based on <a href="https://getavataaars.com/">the work of Pablo Stanley</a>. These are great stand-ins for showing emotion and to represent anonymous user groups.</p>
+
+<p>These are available to GSA staff in two formats:</p>
+<ul>
+	<li>Via the <a href="https://docs.google.com/presentation/d/1CXXvxBbVjO3LjIUwRYEbk8WHpsG0AJdUc6SI_jAZDNQ/edit#slide=id.g5fdac3c814_0_209">starter deck</a>, which includes 10 characters and a range of emotions as well as guidance on different ways to represent humans</li>
+	<li>Via the <a href="https://drive.google.com/drive/folders/1MFGWlJ6Z1ZzIVXK0h0Xh8RsUiBZzYdbg">full sketch library</a> for designers.</li>
+</ul>
 


### PR DESCRIPTION
I wanted to suggest adding some language and links to the avatar work you've done to the Icons pages. Feel free to reject if you have decided this shouldn't be part of the brand site. It occurred to me because I was looking for the avatar stuff on the website, couldn't find it, and then it took me a while to find it in Slack. 

[Preview link](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/brand/18F-Avataaars/icons/)