### PR TITLE
fixing git links in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,9 @@
 <div class="usa-grid">
   <div class="usa-width-one-half">
     <p>Feedback? Create an issue on the <a href="{{ site.repo[0].url }}">GitHub repository</a>.</p>
-    <p>Have an idea? Read our <a href="{{ site.repo[0].url }}/blob/18f-pages-staging/CONTRIBUTING.md">contribution guidelines</a>.</p>
+    <p>Have an idea? Read our <a href="{{ site.repo[0].url }}/blob/master/CONTRIBUTING.md">contribution guidelines</a>.</p>
   </div>
   <div class="usa-width-one-half usa-end-row">
-    <p>As a work of the United States government, this project is <a href="{{ site.repo[0].url }}/blob/18f-pages-staging/LICENSE.md">in the public domain</a>.</p>
+    <p>As a work of the United States government, this project is <a href="{{ site.repo[0].url }}/blob/master/LICENSE.md">in the public domain</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
The git links in the footer go to an old repo url

- updating contributing link
- updating license link