### PR TITLE
fixing button text color, fixing active nav item indicator on mobile

### DIFF
--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -55,6 +55,11 @@ $logo-size-md: 2rem;
 }
 
 // Links
+p.usa-button a {
+  color: $color-white;
+  text-decoration: none;
+}
+
 a {
   color: $color-medium;
 }
@@ -68,7 +73,6 @@ a:hover {
 .usa-header--extended .usa-current:hover::after,
 .usa-nav__primary>.usa-nav__primary-item > .usa-current:hover::after {
   background-color: $color-bright;
-  height: units(0.5);
 }
 
 .usa-nav__primary>.usa-nav__primary-item > .usa-current,
@@ -78,10 +82,6 @@ a:hover {
 
 .usa-nav__primary>.usa-nav__primary-item > a:hover {
   background-color: $color-gray-lightest;
-}
-
-.usa-nav__primary>.usa-nav__primary-item > a:hover::after {
-  height: 0;
 }
 
 .usa-nav__secondary-links {

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -55,10 +55,6 @@ $logo-size-md: 2rem;
 }
 
 // Links
-p.usa-button a {
-  color: $color-white;
-  text-decoration: none;
-}
 
 a {
   color: $color-medium;


### PR DESCRIPTION
Fixes a few small styling bugs I noticed at our demo yesterday, including:
* Fixing the button text color on the logo page
* Fixing the mobile active nav item indicator bar

@igorkorenfeld passing to you for your review! Before and after's below. 

[Federalist preview link](https://federalist-9413b3a7-6641-4d7e-bf2d-fd9440417d07.app.cloud.gov/preview/18f/brand/ik-setup-theme--buttonfix/)

----
### Button text color

Before
<img width="353" alt="Screen Shot 2021-03-10 at 9 56 33 AM" src="https://user-images.githubusercontent.com/2374206/110649132-53b6f780-8187-11eb-85bb-e9286e499ef0.png">

After
<img width="277" alt="Screen Shot 2021-03-10 at 9 55 22 AM" src="https://user-images.githubusercontent.com/2374206/110649095-4b5ebc80-8187-11eb-8d77-3441fc893006.png">


### Mobile active nav indicator

Before
<img width="371" alt="Screen Shot 2021-03-10 at 9 56 45 AM" src="https://user-images.githubusercontent.com/2374206/110649028-3bdf7380-8187-11eb-800a-9b520c893872.png">

After
<img width="303" alt="Screen Shot 2021-03-10 at 9 55 13 AM" src="https://user-images.githubusercontent.com/2374206/110649060-426deb00-8187-11eb-9808-0feb2c8857a6.png">



