### PR TITLE
Add external link icons with exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,11 +80,11 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (>= 4.1.1)
-  jekyll-feed (~> 0.6)
-  jekyll-sitemap
+  jekyll-feed (~> 0.15, >= 0.15.1)
+  jekyll-sitemap (>= 1.4.0)
   redcarpet (~> 3.5.1)
   tzinfo-data
-  uswds-jekyll (~> 5.0)
+  uswds-jekyll (~> 5.3, >= 5.3.0)
   wcag_color_contrast (= 0.0.1)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ scripts:
   - assets/uswds/js/uswds.min.js
   - javascript/application.js
   - javascript/private-eye.js
-#  - javascript/external-links.js
+  - javascript/external-links.js
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/javascript/external-links.js
+++ b/javascript/external-links.js
@@ -1,0 +1,63 @@
+(function() {
+
+  // Parse and return a domain string from a string
+  // returns null if string pattern is not a domain
+  function matchDomain(href) {
+    const hrefDomain = href.match(/^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/?\n]+)/g);
+    if (!hrefDomain) return null;
+    return hrefDomain[0];
+  }
+
+  // Selects only .gov and .mil domains with true
+  // returns false is not
+  function isNonGovDomain(domain) {
+    if (!domain) return false;
+    const segments = domain.split('.');
+    const tld = segments[segments.length - 1];
+    return !(
+      (tld === 'mil') ||
+      (tld === 'gov') ||
+      (tld === 'http://localhost') ||
+      (tld === '1')
+    );
+  }
+
+  function isGoogleDoc(domain) {
+    const googleUrl= 'docs.google.com'
+    return domain.includes(googleUrl);
+  }
+  // Ignore if class has className
+  // IE use for social-link-ico
+  function anchorHasClass(element, className) {
+    return element.className.includes(className);
+  }
+
+  // Select anchor tags, filter non gov domains and add style
+  function styleExternalLinks() {
+    const anchors = document.getElementsByTagName('a');
+    const totalAnchors = anchors.length;
+
+    for (let step = 0; step < totalAnchors; step++) {
+      const a = anchors[step];
+      const isSocialLink = anchorHasClass(a, 'usa-social-link');
+      const isLogo = anchorHasClass(a, 'usa-identifier__logo');
+      const isPrivate = anchorHasClass(a, 'private-link');
+      const domain = matchDomain(a.href);
+      const isDoc = domain.includes('docs.google.com') || domain.includes('drive.google.com');
+      const isSlack = domain.includes('slack.com');
+      const shouldGetIcon = isNonGovDomain(domain)
+        && !isSocialLink
+        && !isLogo
+        && !isDoc
+        && !isSlack;
+
+      if (shouldGetIcon) {
+        a.className = a.className + ' ' + 'usa-link--external';
+        a.setAttribute('title', 'external link"')
+      }
+    }
+  }
+
+  // Run code
+  styleExternalLinks();
+})();


### PR DESCRIPTION
This PR adds external link icons to most links, adding in exceptions for google doc, google drive, and slack (which get the private eye lock icon)

👓  [preview](https://federalist-9413b3a7-6641-4d7e-bf2d-fd9440417d07.app.cloud.gov/preview/18f/brand/link-icons/)