### PR TITLE
Add contact and privacy links

### DIFF
--- a/_data/usa_anchor.yaml
+++ b/_data/usa_anchor.yaml
@@ -30,3 +30,4 @@ anchor_data:
     budget_performance_url: "https://www.gsa.gov/reference/reports/budget-performance"
     accessibility_url: "https://www.gsa.gov/website-information/accessibility-aids"
     usagov_contact_url: "https://www.usa.gov/contact"
+    privacy_policy_url: "https://www.gsa.gov/website-information/website-policies"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,17 @@
 {% assign anchor = site.data.usa_anchor.anchor_data[0] %}
+<div class="usa-footer__secondary-section">
+    <div class="grid-container">
+      <div class="grid-row grid-gap">
+        <div class="usa-footer__contact-links mobile-lg:grid-col-12">
+          <div class="usa-footer grid-row grid-gap-1">
+            <div class="grid-col-auto">
+	      Have questions or would like to contact us? Email us at <a class="usa-link" href="mailto:{{ anchor.org_secondary_email }}">{{ anchor.org_secondary_email }}</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 <div class="usa-identifier">
   <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
     <div class="usa-identifier__container">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -58,6 +58,11 @@
             View No FEAR Act data
           </a>
         </li>
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ anchor.privacy_policy_url }}" title="View privacy policy">
+            Privacy Policy
+          </a>
+        </li>
       </ul>
     </div>
   </nav>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,17 +1,17 @@
 {% assign anchor = site.data.usa_anchor.anchor_data[0] %}
 <div class="usa-footer__secondary-section">
-    <div class="grid-container">
-      <div class="grid-row grid-gap">
-        <div class="usa-footer__contact-links mobile-lg:grid-col-12">
-          <div class="usa-footer grid-row grid-gap-1">
-            <div class="grid-col-auto">
-	      Have questions or would like to contact us? Email us at <a class="usa-link" href="mailto:{{ anchor.org_secondary_email }}">{{ anchor.org_secondary_email }}</a>
-            </div>
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="usa-footer__contact-links mobile-lg:grid-col-12">
+        <div class="usa-footer grid-row grid-gap-1">
+          <div class="grid-col-auto">
+            Have questions or would like to contact us? Email us at <a class="usa-link" href="mailto:{{ anchor.org_secondary_email }}">{{ anchor.org_secondary_email }}</a>
           </div>
         </div>
       </div>
     </div>
   </div>
+</div>
 <div class="usa-identifier">
   <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
     <div class="usa-identifier__container">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,5 @@
 {% assign anchor = site.data.usa_anchor.anchor_data[0] %}
+<footer class="usa-footer" role="contentinfo">
 <div class="usa-footer__secondary-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
@@ -73,3 +74,4 @@
     </div>
   </section>
 </div>
+</footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -60,7 +60,7 @@
         </li>
         <li class="usa-identifier__required-links-item">
           <a class="usa-identifier__required-link usa-link" href="{{ anchor.privacy_policy_url }}" title="View privacy policy">
-            Privacy Policy
+            Privacy policy
           </a>
         </li>
       </ul>


### PR DESCRIPTION
This PR adds a contact us link to the footer and a privacy policy link to the identifier in order to meet the digital council requirements 

👓 [Preview](https://federalist-9413b3a7-6641-4d7e-bf2d-fd9440417d07.app.cloud.gov/preview/18f/brand/ik_add-req-links/)