### PR TITLE
Fix SR reading "image" on color contrast matrix

### DIFF
--- a/_includes/color-matrix.html
+++ b/_includes/color-matrix.html
@@ -24,7 +24,7 @@
 </div>
 
 <div class="usa-matrix-legend legend-bad-contrast">
-  <svg viewBox= "0 0 100 100"><use xlink:href="#usa-matrix-bad-contrast-ratio"/></svg>
+  <svg viewBox= "0 0 100 100" class="usa-sr-invisible" aria-hidden="true"><use xlink:href="#usa-matrix-bad-contrast-ratio"/></svg>
 
   <p class="usa-sr-invisible" aria-hidden="true">
     <strong>Don&rsquo;t</strong> use these color combinations. They don&rsquo;t have enough contrast to meet accessibility standards, and some people will have difficulty reading the text.
@@ -95,8 +95,8 @@
       </td>
       {% else %}
       <td class="usa-matrix-invalid-color-combo">
-        <div title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text." role="presentation">
-          <svg class="usa-matrix-square">
+        <div class="usa-sr-invisible" title="The contrast ratio of {{ foreground.name }} on {{ background.name }} is {{ ratio | human_readable_contrast_ratio }}, which does not conform with the standards of Section 508 for body text." role="presentation" aria-hidden="true">
+          <svg class="usa-matrix-square usa-sr-invisible">
             <use xlink:href="#usa-matrix-bad-contrast-ratio"/>
           </svg>
         </div>


### PR DESCRIPTION
This PR updates the file generating the color contrast matrix so that screen readers don't read "image" for the grey "don't use" color blocks. This makes it consistent with the good color combinations, where the screen reader only reads the combination of colors and announces the color contrast. 

This should also address the failing compliance tests

👓 [Federalist preview](https://federalist-9413b3a7-6641-4d7e-bf2d-fd9440417d07.app.cloud.gov/preview/18f/brand/ik/contrast-alt-text/color-palette//)