### PR TITLE
Update instructions for 18F styles

### DIFF
--- a/pages/templates.md
+++ b/pages/templates.md
@@ -4,14 +4,19 @@ layout: post
 title: Templates
 ---
 ## Google Docs templates
-We have three Google Docs templates:a [basic outline](https://docs.google.com/a/gsa.gov/document/d/1lJBCZwgQzKsX5ggr7ykUaeuAUNqKsthENYCXMTA5Tbs/edit?usp=sharing), a [detailed example](https://docs.google.com/a/gsa.gov/document/d/1BovRM6thz0YWCyd32zwbh-6TYy4ON6GEc8ILDd3RLl8/edit?usp=sharing) with a table of contents, tables, typographic elements, and an appendix, and a [letterhead](https://docs.google.com/document/d/16rQOcP9XYu4qlPwrswTXKO7XBKegxejvXocxo98rW5c/edit?usp=sharing).
+We have three Google Docs templates: a [basic outline](https://docs.google.com/a/gsa.gov/document/d/1lJBCZwgQzKsX5ggr7ykUaeuAUNqKsthENYCXMTA5Tbs/edit?usp=sharing), a [detailed example](https://docs.google.com/a/gsa.gov/document/d/1BovRM6thz0YWCyd32zwbh-6TYy4ON6GEc8ILDd3RLl8/edit?usp=sharing) with a table of contents, tables, typographic elements, and an appendix, and a [letterhead](https://docs.google.com/document/d/16rQOcP9XYu4qlPwrswTXKO7XBKegxejvXocxo98rW5c/edit?usp=sharing).
 
 ### Instructions
 #### To save 18F styles as your default Google styles:
 1. Open the [basic outline](https://docs.google.com/a/gsa.gov/document/d/1lJBCZwgQzKsX5ggr7ykUaeuAUNqKsthENYCXMTA5Tbs/edit?usp=sharing).
-2. In the Styles drop-down menu, choose **Options > Save as my default styles**.
-3. Click **File > New > Document** or open an existing document to apply the 18F styles to it.
-4. In the Styles drop-down menu, choose **Options > Use my default styles**.
+2. In the Styles drop-down menu, choose **Options > Save as my default styles**. Any new Google document you create will use the 18F styles by default.
+<img width="759" alt="Screenshot showing how to save 18F styles" src="https://user-images.githubusercontent.com/42982184/205963114-dd5be0c9-fc56-4270-ba61-f017b35d7398.png">
+
+#### To apply 18F styles to an existing Google document:
+1. Follow the instructions above to save 18F styles as your default Google styles. 
+2. Open an existing document you want to apply the 18F styles to.
+3. In the Styles drop-down menu, choose **Options > Use my default styles**. This will apply the 18F styles and override any existing styles in the document. 
+<img width="763" alt="Screenshot showing how to apply 18F styles" src="https://user-images.githubusercontent.com/42982184/205963242-dd71845e-ca25-4a60-8142-8b3335a39bfe.png">
 
 #### To reuse specific tables or typographic elements in a Google Doc:
 1. Open the [detailed example](https://docs.google.com/a/gsa.gov/document/d/1BovRM6thz0YWCyd32zwbh-6TYy4ON6GEc8ILDd3RLl8/edit?usp=sharing).


### PR DESCRIPTION
Now that we have included installing 18F styles as part of new hires' checklists, this clarifies the instructions for saving the styles as default styles and applying them to existing documents. Adds screenshots since the "Styles dropdown" may not be intuitive to find.

(Also adds a missing space in the first sentence of the page)